### PR TITLE
feat(schema): add runtime entity/relation type registry (Stage 1)

### DIFF
--- a/src/docdb/schema/connection.py
+++ b/src/docdb/schema/connection.py
@@ -10,6 +10,7 @@ import sqlite_vec
 
 
 _SCHEMA_RESOURCE = ("docdb.schema", "schema.sql")
+_SEED_RESOURCE = ("docdb.schema", "seed.sql")
 
 
 def _load_extensions(conn: sqlite3.Connection) -> None:
@@ -46,15 +47,29 @@ def get_connection(db_path: Path | str, *, readonly: bool = False) -> sqlite3.Co
     return conn
 
 
-def _read_schema_sql() -> str:
-    package, name = _SCHEMA_RESOURCE
+def _read_resource(resource: tuple[str, str]) -> str:
+    package, name = resource
     return resources.files(package).joinpath(name).read_text(encoding="utf-8")
 
 
+def _read_schema_sql() -> str:
+    return _read_resource(_SCHEMA_RESOURCE)
+
+
+def _read_seed_sql() -> str:
+    return _read_resource(_SEED_RESOURCE)
+
+
 def init_db(db_path: Path | str) -> None:
-    """Create the database file (if missing) and apply schema.sql idempotently."""
+    """Create the database file (if missing) and apply schema + seeds idempotently.
+
+    schema.sql defines the table layout; seed.sql ships built-in type
+    definitions (person/org/place/task/...). Both use INSERT OR IGNORE
+    so re-running is safe and never clobbers user edits.
+    """
     with get_connection(db_path) as conn:
         conn.executescript(_read_schema_sql())
+        conn.executescript(_read_seed_sql())
         conn.commit()
 
 

--- a/src/docdb/schema/schema.sql
+++ b/src/docdb/schema/schema.sql
@@ -1,4 +1,4 @@
--- DocDB schema v1
+-- DocDB schema v2
 -- All tables intended for the agentic search layer are defined here.
 -- Virtual tables (FTS5, sqlite-vec) require the respective extensions
 -- to be loaded on the connection before this DDL is applied.
@@ -37,7 +37,49 @@ CREATE INDEX IF NOT EXISTS idx_documents_created_at ON documents(created_at);
 CREATE INDEX IF NOT EXISTS idx_documents_source_path ON documents(source_path);
 
 -- ============================================================
--- Entities (people, orgs, products, tech, places, ...)
+-- Type registry (Stage 1 of property-graph redesign)
+-- ============================================================
+-- entity_types and relation_types are user-editable at runtime.
+-- fields_schema is a JSON FieldSpec[]; see docdb.typing.field_spec.
+-- These coexist with the legacy `entities`/`todos` tables until Stage 2.
+CREATE TABLE IF NOT EXISTS entity_types (
+    slug             TEXT PRIMARY KEY,
+    label            TEXT NOT NULL,
+    description      TEXT,
+    icon             TEXT,
+    color            TEXT,
+    fields_schema    TEXT NOT NULL DEFAULT '[]',
+    extraction_hint  TEXT,
+    is_builtin       INTEGER NOT NULL DEFAULT 0,
+    created_ts       TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_ts       TEXT NOT NULL DEFAULT (datetime('now')),
+    CHECK (json_valid(fields_schema))
+);
+
+CREATE TABLE IF NOT EXISTS relation_types (
+    slug              TEXT PRIMARY KEY,
+    label             TEXT NOT NULL,
+    description       TEXT,
+    inverse_label     TEXT,
+    source_type_slug  TEXT,                     -- NULL = any
+    target_type_slug  TEXT,
+    fields_schema     TEXT NOT NULL DEFAULT '[]',
+    extraction_hint   TEXT,
+    is_builtin        INTEGER NOT NULL DEFAULT 0,
+    created_ts        TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_ts        TEXT NOT NULL DEFAULT (datetime('now')),
+    CHECK (json_valid(fields_schema)),
+    FOREIGN KEY(source_type_slug) REFERENCES entity_types(slug) ON DELETE SET NULL,
+    FOREIGN KEY(target_type_slug) REFERENCES entity_types(slug) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_relation_types_src ON relation_types(source_type_slug);
+CREATE INDEX IF NOT EXISTS idx_relation_types_dst ON relation_types(target_type_slug);
+
+-- ============================================================
+-- Entities (LEGACY — to be dropped in Stage 2)
+-- Current shape uses a fixed entity_type enum. Property-graph entities
+-- replace this table in Stage 2 once the type registry is in place.
 -- ============================================================
 CREATE TABLE IF NOT EXISTS entities (
     id              TEXT PRIMARY KEY,
@@ -181,4 +223,4 @@ CREATE VIRTUAL TABLE IF NOT EXISTS tags_vec USING vec0(
     embedding float[1024]
 );
 
-INSERT OR IGNORE INTO schema_version(version) VALUES (1);
+INSERT OR IGNORE INTO schema_version(version) VALUES (2);

--- a/src/docdb/schema/seed.sql
+++ b/src/docdb/schema/seed.sql
@@ -1,0 +1,48 @@
+-- DocDB built-in type seeds (idempotent).
+-- Inserted after schema.sql so that a fresh database has the familiar
+-- person / org / place / task entity types and the assigned_to / mentions
+-- relation types available out of the box.
+--
+-- These rows are INSERT OR IGNORE: if a user has edited the same slug,
+-- the existing row wins. Built-ins are marked with is_builtin = 1 so the
+-- Settings UI can render them differently (e.g., prevent deletion).
+
+INSERT OR IGNORE INTO entity_types (slug, label, description, fields_schema, extraction_hint, is_builtin)
+VALUES
+    ('person', '人物', '実在 / 言及された個人。組織名や役職と混同しない。',
+     '[]',
+     '本文中で言及された人名のみ。役職や敬称は canonical_name に含めない。',
+     1),
+    ('org', '組織', '会社・チーム・学校・部署など。',
+     '[]',
+     '組織・チーム・部署。略称は aliases に。',
+     1),
+    ('place', '場所', '地名・施設名・部屋など。',
+     '[]',
+     '地名・建物名・会議室など物理的な場所。',
+     1),
+    ('task',
+     'タスク',
+     '本文に書かれた未完了の作業項目。',
+     '[
+        {"name":"status","label":"Status","type":"enum","required":true,"default":"pending",
+         "options":["pending","in_progress","completed","cancelled"]},
+        {"name":"priority","label":"Priority","type":"enum","required":true,"default":"medium",
+         "options":["high","medium","low"]},
+        {"name":"due_date","label":"Due","type":"date","required":false}
+      ]',
+     '未完了の作業項目のみ抽出。完了済み (例: [x]) は除外。canonical_name はタスク本文そのもの。緊急/asap/急 → priority=high、後で/将来 → low、それ以外は medium。',
+     1);
+
+INSERT OR IGNORE INTO relation_types (slug, label, description, inverse_label, fields_schema, extraction_hint, is_builtin)
+VALUES
+    ('assigned_to', '担当', 'タスクや責務を人物 / 組織に紐付ける。',
+     'has_assignment',
+     '[]',
+     'タスク entity から人物 / 組織 entity へ。',
+     1),
+    ('mentions', '言及', '広い意味で関連あり (デフォルトの弱い結合)。',
+     'mentioned_by',
+     '[]',
+     '具体的な意味関係が分からない場合の汎用エッジ。',
+     1);

--- a/src/docdb/typing/__init__.py
+++ b/src/docdb/typing/__init__.py
@@ -1,0 +1,7 @@
+"""Runtime type registry and field-spec validation for the property-graph model.
+
+Stage 1 introduces ``entity_types`` / ``relation_types`` tables whose
+``fields_schema`` column is a JSON ``FieldSpec[]``. The pure-Python helpers
+in this package parse and validate those schemas, and build dynamic Pydantic
+models that the LLM extraction layer can pass to ``instructor``.
+"""

--- a/src/docdb/typing/field_spec.py
+++ b/src/docdb/typing/field_spec.py
@@ -1,0 +1,267 @@
+"""FieldSpec: the schema-of-schema for user-definable entity / relation fields.
+
+Each ``entity_types.fields_schema`` row is a JSON array of FieldSpec entries.
+Ten primitive types are supported (``string`` ... ``ref``); the renderer on
+the frontend dispatches on ``type`` and produces the right widget.
+
+Two services live here:
+
+- ``parse_fields_schema`` / ``validate_fields`` — used by the server
+  (Stage 1 type CRUD and Stage 2 entity CRUD) to ensure that a user-supplied
+  ``fields_schema`` (or a payload conforming to one) is well-formed.
+
+- ``build_dynamic_model`` — used by the LLM extraction layer (Stage 3) to
+  produce a concrete ``pydantic.BaseModel`` per type, since ``instructor``
+  requires a class at call time. The class is keyed by ``model_name`` so the
+  caller can avoid Pydantic / instructor schema cache collisions.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import date, datetime
+from typing import Annotated, Any, Literal, Union
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    TypeAdapter,
+    create_model,
+    field_validator,
+)
+
+
+_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class _BaseSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=64)
+    label: str = Field(min_length=1, max_length=128)
+    required: bool = False
+    default: Any | None = None
+    ui_widget: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _valid_name(cls, v: str) -> str:
+        if not _NAME_RE.match(v):
+            raise ValueError(
+                f"field name must be snake_case (lowercase letters, digits, underscores; "
+                f"start with letter): got {v!r}"
+            )
+        return v
+
+
+class FieldSpecString(_BaseSpec):
+    type: Literal["string"]
+
+
+class FieldSpecText(_BaseSpec):
+    type: Literal["text"]
+
+
+class FieldSpecInt(_BaseSpec):
+    type: Literal["int"]
+
+
+class FieldSpecFloat(_BaseSpec):
+    type: Literal["float"]
+
+
+class FieldSpecBool(_BaseSpec):
+    type: Literal["bool"]
+
+
+class FieldSpecDate(_BaseSpec):
+    type: Literal["date"]
+
+
+class FieldSpecDateTime(_BaseSpec):
+    type: Literal["datetime"]
+
+
+class FieldSpecEnum(_BaseSpec):
+    type: Literal["enum"]
+    options: list[str] = Field(min_length=1)
+
+
+class FieldSpecUrl(_BaseSpec):
+    type: Literal["url"]
+
+
+class FieldSpecRef(_BaseSpec):
+    type: Literal["ref"]
+    ref_type_slug: str | None = None
+
+
+FieldSpec = Annotated[
+    Union[
+        FieldSpecString,
+        FieldSpecText,
+        FieldSpecInt,
+        FieldSpecFloat,
+        FieldSpecBool,
+        FieldSpecDate,
+        FieldSpecDateTime,
+        FieldSpecEnum,
+        FieldSpecUrl,
+        FieldSpecRef,
+    ],
+    Field(discriminator="type"),
+]
+
+
+_SpecListAdapter: TypeAdapter[list[FieldSpec]] = TypeAdapter(list[FieldSpec])
+
+
+def parse_fields_schema(raw: str | list[dict]) -> list[FieldSpec]:
+    """Validate a raw fields_schema (JSON string or python list) into FieldSpec objects.
+
+    Raises ``pydantic.ValidationError`` for type errors and ``ValueError`` for
+    cross-field issues (e.g., duplicate names).
+    """
+    payload = json.loads(raw) if isinstance(raw, str) else raw
+    specs = _SpecListAdapter.validate_python(payload)
+    seen: set[str] = set()
+    for spec in specs:
+        if spec.name in seen:
+            raise ValueError(f"duplicate field name in fields_schema: {spec.name!r}")
+        seen.add(spec.name)
+    return specs
+
+
+def dump_fields_schema(specs: list[FieldSpec]) -> str:
+    """Serialize a FieldSpec list back to a JSON string for persistence."""
+    return json.dumps([s.model_dump(exclude_none=True) for s in specs], ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Semantic validation of a payload against a fields_schema.
+# ---------------------------------------------------------------------------
+def validate_fields(specs: list[FieldSpec], payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate a JSON payload against a fields_schema.
+
+    Behaviour:
+    - Unknown keys in ``payload`` are dropped (forward-compatible).
+    - Missing optional fields default to ``None``.
+    - Missing required fields fall back to the spec ``default`` if present;
+      otherwise ``ValueError`` is raised.
+    - Empty strings on optional fields coerce to ``None``.
+    - Type-specific coercion is delegated to ``_coerce_value``.
+
+    Returns a fresh dict containing only the validated values.
+    """
+    out: dict[str, Any] = {}
+    for spec in specs:
+        raw_value = payload.get(spec.name)
+
+        if isinstance(raw_value, str) and raw_value == "" and not spec.required:
+            raw_value = None
+
+        if raw_value is None and spec.default is not None:
+            raw_value = spec.default
+
+        if raw_value is None:
+            if spec.required:
+                raise ValueError(f"missing required field: {spec.name!r}")
+            out[spec.name] = None
+            continue
+
+        out[spec.name] = _coerce_value(spec, raw_value)
+    return out
+
+
+def _coerce_value(spec: Any, value: Any) -> Any:
+    t = spec.type
+    if t in ("string", "text"):
+        if not isinstance(value, str):
+            raise ValueError(f"{spec.name}: expected string, got {type(value).__name__}")
+        return value
+    if t == "int":
+        if isinstance(value, bool):  # bool is a subclass of int — reject explicitly
+            raise ValueError(f"{spec.name}: expected int, got bool")
+        try:
+            return int(value)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"{spec.name}: expected int ({exc})")
+    if t == "float":
+        if isinstance(value, bool):
+            raise ValueError(f"{spec.name}: expected float, got bool")
+        try:
+            return float(value)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"{spec.name}: expected float ({exc})")
+    if t == "bool":
+        if not isinstance(value, bool):
+            raise ValueError(f"{spec.name}: expected bool")
+        return value
+    if t == "date":
+        if not isinstance(value, str):
+            raise ValueError(f"{spec.name}: expected date string")
+        try:
+            date.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(f"{spec.name}: invalid ISO date ({exc})")
+        return value
+    if t == "datetime":
+        if not isinstance(value, str):
+            raise ValueError(f"{spec.name}: expected datetime string")
+        try:
+            datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(f"{spec.name}: invalid ISO datetime ({exc})")
+        return value
+    if t == "enum":
+        if value not in spec.options:
+            raise ValueError(f"{spec.name}: value {value!r} not in options {spec.options!r}")
+        return value
+    if t == "url":
+        if isinstance(value, str) and (value.startswith("http://") or value.startswith("https://")):
+            return value
+        raise ValueError(f"{spec.name}: expected http(s) URL")
+    if t == "ref":
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{spec.name}: expected entity id string")
+        return value
+    raise ValueError(f"{spec.name}: unknown field type {t!r}")
+
+
+# ---------------------------------------------------------------------------
+# Dynamic Pydantic model construction (for LLM extraction).
+# ---------------------------------------------------------------------------
+def build_dynamic_model(model_name: str, specs: list[FieldSpec]) -> type[BaseModel]:
+    """Construct a Pydantic model class whose fields mirror the spec list."""
+    field_defs: dict[str, tuple[Any, Any]] = {}
+    for spec in specs:
+        py_type, default = _python_field(spec)
+        field_defs[spec.name] = (py_type, default)
+    return create_model(model_name, **field_defs)  # type: ignore[call-overload]
+
+
+def _python_field(spec: Any) -> tuple[Any, Any]:
+    t = spec.type
+    if t in ("string", "text", "url", "date", "datetime", "ref"):
+        py: Any = str
+    elif t == "int":
+        py = int
+    elif t == "float":
+        py = float
+    elif t == "bool":
+        py = bool
+    elif t == "enum":
+        py = Literal[tuple(spec.options)]  # type: ignore[valid-type]
+    else:
+        raise ValueError(f"unknown field type: {t!r}")
+
+    optional = not spec.required
+    if optional:
+        py = py | None  # type: ignore[operator]
+        default = spec.default
+    else:
+        default = spec.default if spec.default is not None else ...
+
+    return py, default

--- a/src/docdb/typing/registry.py
+++ b/src/docdb/typing/registry.py
@@ -1,0 +1,262 @@
+"""Read / write access to the runtime type registry.
+
+Two simple Pydantic record types wrap the rows in ``entity_types`` and
+``relation_types``. The ``fields_schema`` JSON column is parsed eagerly into
+``FieldSpec`` objects on the way out, and re-serialised on upsert.
+
+``registry_hash`` is a stable hash over ``(slug, updated_ts)`` tuples used
+by Stage 3 to invalidate dynamic-Pydantic / instructor caches.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from docdb.typing.field_spec import (
+    FieldSpec,
+    dump_fields_schema,
+    parse_fields_schema,
+)
+
+
+def _now_iso() -> str:
+    return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+class _TypeBase(BaseModel):
+    """Shared columns between entity_types and relation_types."""
+
+    model_config = ConfigDict(extra="ignore", arbitrary_types_allowed=True)
+
+    slug: str = Field(min_length=1, max_length=64, pattern=r"^[a-z][a-z0-9_]*$")
+    label: str = Field(min_length=1, max_length=128)
+    description: str | None = None
+    fields: list[FieldSpec] = Field(default_factory=list)
+    extraction_hint: str | None = None
+    is_builtin: bool = False
+    created_ts: str | None = None
+    updated_ts: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_fields_schema_alias(cls, data: Any) -> Any:
+        # The DB column is named `fields_schema`; in-memory the attribute is
+        # `fields`. Accept either form for ergonomics in tests/API payloads.
+        if isinstance(data, dict) and "fields_schema" in data and "fields" not in data:
+            raw = data.pop("fields_schema")
+            data["fields"] = parse_fields_schema(raw)
+        elif isinstance(data, dict) and "fields" in data:
+            field_value = data["fields"]
+            if isinstance(field_value, (str, list)) and (
+                isinstance(field_value, str)
+                or (isinstance(field_value, list) and field_value and isinstance(field_value[0], dict))
+                or field_value == []
+            ):
+                data["fields"] = parse_fields_schema(field_value)
+        return data
+
+
+class EntityTypeDef(_TypeBase):
+    icon: str | None = None
+    color: str | None = None
+
+
+class RelationTypeDef(_TypeBase):
+    inverse_label: str | None = None
+    source_type_slug: str | None = None
+    target_type_slug: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Row → object decoders
+# ---------------------------------------------------------------------------
+def _row_to_entity_type(row: sqlite3.Row) -> EntityTypeDef:
+    return EntityTypeDef.model_validate(
+        {
+            "slug": row["slug"],
+            "label": row["label"],
+            "description": row["description"],
+            "icon": row["icon"],
+            "color": row["color"],
+            "fields_schema": row["fields_schema"] or "[]",
+            "extraction_hint": row["extraction_hint"],
+            "is_builtin": bool(row["is_builtin"]),
+            "created_ts": row["created_ts"],
+            "updated_ts": row["updated_ts"],
+        }
+    )
+
+
+def _row_to_relation_type(row: sqlite3.Row) -> RelationTypeDef:
+    return RelationTypeDef.model_validate(
+        {
+            "slug": row["slug"],
+            "label": row["label"],
+            "description": row["description"],
+            "inverse_label": row["inverse_label"],
+            "source_type_slug": row["source_type_slug"],
+            "target_type_slug": row["target_type_slug"],
+            "fields_schema": row["fields_schema"] or "[]",
+            "extraction_hint": row["extraction_hint"],
+            "is_builtin": bool(row["is_builtin"]),
+            "created_ts": row["created_ts"],
+            "updated_ts": row["updated_ts"],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entity type CRUD
+# ---------------------------------------------------------------------------
+def list_entity_types(conn: sqlite3.Connection) -> list[EntityTypeDef]:
+    rows = conn.execute(
+        "SELECT slug, label, description, icon, color, fields_schema, extraction_hint, "
+        "       is_builtin, created_ts, updated_ts FROM entity_types ORDER BY slug"
+    ).fetchall()
+    return [_row_to_entity_type(r) for r in rows]
+
+
+def get_entity_type(conn: sqlite3.Connection, slug: str) -> EntityTypeDef | None:
+    row = conn.execute(
+        "SELECT slug, label, description, icon, color, fields_schema, extraction_hint, "
+        "       is_builtin, created_ts, updated_ts FROM entity_types WHERE slug = ?",
+        (slug,),
+    ).fetchone()
+    return _row_to_entity_type(row) if row else None
+
+
+def upsert_entity_type(conn: sqlite3.Connection, type_def: EntityTypeDef) -> EntityTypeDef:
+    now = _now_iso()
+    conn.execute(
+        """
+        INSERT INTO entity_types (slug, label, description, icon, color, fields_schema,
+                                  extraction_hint, is_builtin, created_ts, updated_ts)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE((SELECT created_ts FROM entity_types WHERE slug = ?), ?), ?)
+        ON CONFLICT(slug) DO UPDATE SET
+            label = excluded.label,
+            description = excluded.description,
+            icon = excluded.icon,
+            color = excluded.color,
+            fields_schema = excluded.fields_schema,
+            extraction_hint = excluded.extraction_hint,
+            is_builtin = excluded.is_builtin,
+            updated_ts = excluded.updated_ts
+        """,
+        (
+            type_def.slug,
+            type_def.label,
+            type_def.description,
+            type_def.icon,
+            type_def.color,
+            dump_fields_schema(type_def.fields),
+            type_def.extraction_hint,
+            1 if type_def.is_builtin else 0,
+            type_def.slug,
+            now,
+            now,
+        ),
+    )
+    conn.commit()
+    result = get_entity_type(conn, type_def.slug)
+    assert result is not None
+    return result
+
+
+def delete_entity_type(conn: sqlite3.Connection, slug: str) -> bool:
+    cur = conn.execute("DELETE FROM entity_types WHERE slug = ?", (slug,))
+    conn.commit()
+    return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Relation type CRUD
+# ---------------------------------------------------------------------------
+def list_relation_types(conn: sqlite3.Connection) -> list[RelationTypeDef]:
+    rows = conn.execute(
+        "SELECT slug, label, description, inverse_label, source_type_slug, target_type_slug, "
+        "       fields_schema, extraction_hint, is_builtin, created_ts, updated_ts "
+        "FROM relation_types ORDER BY slug"
+    ).fetchall()
+    return [_row_to_relation_type(r) for r in rows]
+
+
+def get_relation_type(conn: sqlite3.Connection, slug: str) -> RelationTypeDef | None:
+    row = conn.execute(
+        "SELECT slug, label, description, inverse_label, source_type_slug, target_type_slug, "
+        "       fields_schema, extraction_hint, is_builtin, created_ts, updated_ts "
+        "FROM relation_types WHERE slug = ?",
+        (slug,),
+    ).fetchone()
+    return _row_to_relation_type(row) if row else None
+
+
+def upsert_relation_type(conn: sqlite3.Connection, type_def: RelationTypeDef) -> RelationTypeDef:
+    now = _now_iso()
+    conn.execute(
+        """
+        INSERT INTO relation_types (slug, label, description, inverse_label, source_type_slug,
+                                    target_type_slug, fields_schema, extraction_hint, is_builtin,
+                                    created_ts, updated_ts)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+                COALESCE((SELECT created_ts FROM relation_types WHERE slug = ?), ?), ?)
+        ON CONFLICT(slug) DO UPDATE SET
+            label = excluded.label,
+            description = excluded.description,
+            inverse_label = excluded.inverse_label,
+            source_type_slug = excluded.source_type_slug,
+            target_type_slug = excluded.target_type_slug,
+            fields_schema = excluded.fields_schema,
+            extraction_hint = excluded.extraction_hint,
+            is_builtin = excluded.is_builtin,
+            updated_ts = excluded.updated_ts
+        """,
+        (
+            type_def.slug,
+            type_def.label,
+            type_def.description,
+            type_def.inverse_label,
+            type_def.source_type_slug,
+            type_def.target_type_slug,
+            dump_fields_schema(type_def.fields),
+            type_def.extraction_hint,
+            1 if type_def.is_builtin else 0,
+            type_def.slug,
+            now,
+            now,
+        ),
+    )
+    conn.commit()
+    result = get_relation_type(conn, type_def.slug)
+    assert result is not None
+    return result
+
+
+def delete_relation_type(conn: sqlite3.Connection, slug: str) -> bool:
+    cur = conn.execute("DELETE FROM relation_types WHERE slug = ?", (slug,))
+    conn.commit()
+    return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Hash for cache invalidation
+# ---------------------------------------------------------------------------
+def registry_hash(conn: sqlite3.Connection) -> str:
+    """Stable hash over (slug, updated_ts) tuples for both type tables.
+
+    Stage 3 uses this to key the dynamic-Pydantic / instructor schema cache.
+    """
+    rows = conn.execute(
+        "SELECT 'e' AS kind, slug, updated_ts FROM entity_types "
+        "UNION ALL "
+        "SELECT 'r' AS kind, slug, updated_ts FROM relation_types "
+        "ORDER BY kind, slug"
+    ).fetchall()
+    h = hashlib.sha256()
+    for r in rows:
+        h.update(f"{r['kind']}|{r['slug']}|{r['updated_ts']}\n".encode("utf-8"))
+    return h.hexdigest()

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import DocumentDetail from "./routes/DocumentDetail";
 import Todos from "./routes/Todos";
 import Entities from "./routes/Entities";
 import Ingest from "./routes/Ingest";
+import Settings from "./routes/Settings";
 
 export default function App() {
   return (
@@ -19,6 +20,7 @@ export default function App() {
         <Route path="todos" element={<Todos />} />
         <Route path="entities" element={<Entities />} />
         <Route path="ingest" element={<Ingest />} />
+        <Route path="settings" element={<Settings />} />
       </Route>
     </Routes>
   );

--- a/src/frontend/src/api/types.ts
+++ b/src/frontend/src/api/types.ts
@@ -1,4 +1,53 @@
 export type DocType = "memo" | "meeting" | "journal" | "reference" | "spec" | "other";
+
+// ---------------------------------------------------------------------------
+// Type registry (Stage 1 of property-graph redesign)
+// ---------------------------------------------------------------------------
+export type FieldSpecType =
+  | "string"
+  | "text"
+  | "int"
+  | "float"
+  | "bool"
+  | "date"
+  | "datetime"
+  | "enum"
+  | "url"
+  | "ref";
+
+export interface FieldSpec {
+  name: string;
+  label: string;
+  type: FieldSpecType;
+  required?: boolean;
+  default?: unknown;
+  ui_widget?: string;
+  options?: string[];        // enum only
+  ref_type_slug?: string;    // ref only
+}
+
+interface TypeDefBase {
+  slug: string;
+  label: string;
+  description: string | null;
+  fields_schema: FieldSpec[];
+  extraction_hint: string | null;
+  is_builtin: boolean;
+  created_ts: string | null;
+  updated_ts: string | null;
+}
+
+export interface EntityTypeDef extends TypeDefBase {
+  icon: string | null;
+  color: string | null;
+}
+
+export interface RelationTypeDef extends TypeDefBase {
+  inverse_label: string | null;
+  source_type_slug: string | null;
+  target_type_slug: string | null;
+}
+
 export type TodoStatus = "pending" | "in_progress" | "completed" | "cancelled";
 export type Priority = "high" | "medium" | "low";
 export type EntityType = "person" | "org" | "product" | "tech" | "place" | "other";

--- a/src/frontend/src/components/Layout.tsx
+++ b/src/frontend/src/components/Layout.tsx
@@ -8,6 +8,7 @@ const NAV = [
   { to: "/todos", label: "Todos", end: false },
   { to: "/entities", label: "Entities", end: false },
   { to: "/ingest", label: "Ingest", end: false },
+  { to: "/settings", label: "Settings", end: false },
 ];
 
 export default function Layout() {

--- a/src/frontend/src/routes/Settings.module.css
+++ b/src/frontend/src/routes/Settings.module.css
@@ -1,0 +1,111 @@
+.tabs {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tab {
+  padding: var(--space-2) var(--space-3);
+  background: transparent;
+  color: var(--color-text-muted);
+  border: 0;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.tab:hover {
+  color: var(--color-text);
+}
+
+.tabActive {
+  color: var(--color-text);
+  border-bottom-color: var(--color-accent);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.cardHead {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  justify-content: space-between;
+}
+
+.slug {
+  font-family: var(--font-mono, monospace);
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.label {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.description {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.fieldList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+
+.fieldRow {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--color-text);
+}
+
+.fieldName {
+  font-family: var(--font-mono, monospace);
+}
+
+.fieldType {
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.empty {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+.hint {
+  background-color: var(--color-surface-alt, var(--color-surface));
+  border-left: 3px solid var(--color-accent);
+  padding: var(--space-1) var(--space-2);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.placeholder {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  margin-top: var(--space-3);
+  font-style: italic;
+}

--- a/src/frontend/src/routes/Settings.tsx
+++ b/src/frontend/src/routes/Settings.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import useSWR from "swr";
+import { fetcher } from "../api/client";
+import type {
+  EntityTypeDef,
+  FieldSpec,
+  RelationTypeDef,
+} from "../api/types";
+import PageHeader from "../components/PageHeader";
+import Badge from "../components/Badge";
+import EmptyState from "../components/EmptyState";
+import styles from "./Settings.module.css";
+
+type Tab = "entities" | "relations";
+
+export default function Settings() {
+  const [tab, setTab] = useState<Tab>("entities");
+
+  const { data: entityTypes } = useSWR<EntityTypeDef[]>(
+    "/api/types/entities",
+    fetcher,
+  );
+  const { data: relationTypes } = useSWR<RelationTypeDef[]>(
+    "/api/types/relations",
+    fetcher,
+  );
+
+  return (
+    <div>
+      <PageHeader
+        title="Settings"
+        subtitle="Entity / Relation type registry (read-only in Stage 1)"
+      />
+
+      <div className={styles.tabs}>
+        <button
+          className={tab === "entities" ? `${styles.tab} ${styles.tabActive}` : styles.tab}
+          onClick={() => setTab("entities")}
+        >
+          Entity types ({entityTypes?.length ?? 0})
+        </button>
+        <button
+          className={tab === "relations" ? `${styles.tab} ${styles.tabActive}` : styles.tab}
+          onClick={() => setTab("relations")}
+        >
+          Relation types ({relationTypes?.length ?? 0})
+        </button>
+      </div>
+
+      {tab === "entities" && <EntityTypeList items={entityTypes} />}
+      {tab === "relations" && <RelationTypeList items={relationTypes} />}
+
+      <p className={styles.placeholder}>
+        編集 UI は Stage 4 で追加されます。Stage 1 は登録済みの型を確認するための画面です。
+      </p>
+    </div>
+  );
+}
+
+function EntityTypeList({ items }: { items?: EntityTypeDef[] }) {
+  if (!items) return null;
+  if (items.length === 0) return <EmptyState title="No entity types defined" />;
+  return (
+    <div className={styles.list}>
+      {items.map((t) => (
+        <article key={t.slug} className={styles.card}>
+          <div className={styles.cardHead}>
+            <div>
+              <span className={styles.label}>{t.label}</span>{" "}
+              <span className={styles.slug}>{t.slug}</span>
+            </div>
+            {t.is_builtin && <Badge tone="muted">built-in</Badge>}
+          </div>
+          {t.description && <div className={styles.description}>{t.description}</div>}
+          <FieldSchemaList fields={t.fields_schema} />
+          {t.extraction_hint && (
+            <div className={styles.hint}>
+              <strong>LLM hint:</strong> {t.extraction_hint}
+            </div>
+          )}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function RelationTypeList({ items }: { items?: RelationTypeDef[] }) {
+  if (!items) return null;
+  if (items.length === 0) return <EmptyState title="No relation types defined" />;
+  return (
+    <div className={styles.list}>
+      {items.map((t) => (
+        <article key={t.slug} className={styles.card}>
+          <div className={styles.cardHead}>
+            <div>
+              <span className={styles.label}>{t.label}</span>{" "}
+              <span className={styles.slug}>{t.slug}</span>
+              {t.inverse_label && (
+                <span className={styles.slug}> ⇄ {t.inverse_label}</span>
+              )}
+            </div>
+            {t.is_builtin && <Badge tone="muted">built-in</Badge>}
+          </div>
+          {t.description && <div className={styles.description}>{t.description}</div>}
+          <div className={styles.fieldRow}>
+            <span className={styles.fieldType}>source:</span>
+            <span className={styles.fieldName}>{t.source_type_slug ?? "any"}</span>
+            <span className={styles.fieldType}>→ target:</span>
+            <span className={styles.fieldName}>{t.target_type_slug ?? "any"}</span>
+          </div>
+          <FieldSchemaList fields={t.fields_schema} />
+          {t.extraction_hint && (
+            <div className={styles.hint}>
+              <strong>LLM hint:</strong> {t.extraction_hint}
+            </div>
+          )}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function FieldSchemaList({ fields }: { fields: FieldSpec[] }) {
+  if (fields.length === 0) {
+    return <div className={styles.empty}>(no custom fields)</div>;
+  }
+  return (
+    <div className={styles.fieldList}>
+      {fields.map((f) => (
+        <div key={f.name} className={styles.fieldRow}>
+          <span className={styles.fieldName}>{f.name}</span>
+          <span className={styles.fieldType}>: {f.type}</span>
+          {f.required && <Badge tone="warning">required</Badge>}
+          {f.type === "enum" && f.options && (
+            <span className={styles.fieldType}>[{f.options.join(", ")}]</span>
+          )}
+          {f.default !== undefined && f.default !== null && (
+            <span className={styles.fieldType}>
+              default: {String(f.default)}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/server/routes/__init__.py
+++ b/src/server/routes/__init__.py
@@ -13,6 +13,7 @@ from server.routes import (
     search,
     stats,
     todos,
+    types,
 )
 
 
@@ -22,6 +23,7 @@ def register_routes(app: Flask) -> None:
     app.register_blueprint(documents.bp)
     app.register_blueprint(entities.bp)
     app.register_blueprint(todos.bp)
+    app.register_blueprint(types.bp)
     app.register_blueprint(search.bp)
     app.register_blueprint(ask.bp)
     app.register_blueprint(ingest.bp)

--- a/src/server/routes/types.py
+++ b/src/server/routes/types.py
@@ -1,0 +1,194 @@
+"""CRUD endpoints for the runtime type registry.
+
+Two URL prefixes share this blueprint:
+    /api/types/entities    — entity_types CRUD
+    /api/types/relations   — relation_types CRUD
+
+The endpoints are deliberately thin: all schema validation lives in
+``docdb.typing.field_spec`` and ``docdb.typing.registry``. ValueError /
+ValidationError raised there is rendered as a 400.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from flask import Blueprint, jsonify, request
+from pydantic import ValidationError
+
+from docdb.typing.registry import (
+    EntityTypeDef,
+    RelationTypeDef,
+    delete_entity_type,
+    delete_relation_type,
+    get_entity_type,
+    get_relation_type,
+    list_entity_types,
+    list_relation_types,
+    upsert_entity_type,
+    upsert_relation_type,
+)
+
+from server.context import get_conn
+
+
+bp = Blueprint("types", __name__, url_prefix="/api/types")
+
+
+def _type_to_payload(td) -> dict:
+    """Render an EntityTypeDef / RelationTypeDef to the API JSON shape."""
+    base = {
+        "slug": td.slug,
+        "label": td.label,
+        "description": td.description,
+        "fields_schema": [f.model_dump(exclude_none=True) for f in td.fields],
+        "extraction_hint": td.extraction_hint,
+        "is_builtin": td.is_builtin,
+        "created_ts": td.created_ts,
+        "updated_ts": td.updated_ts,
+    }
+    if isinstance(td, EntityTypeDef):
+        base["icon"] = td.icon
+        base["color"] = td.color
+    elif isinstance(td, RelationTypeDef):
+        base["inverse_label"] = td.inverse_label
+        base["source_type_slug"] = td.source_type_slug
+        base["target_type_slug"] = td.target_type_slug
+    return base
+
+
+def _client_error(message: str, status: int = 400):
+    return jsonify({"error": message}), status
+
+
+# ---------------------------------------------------------------------------
+# Entity types
+# ---------------------------------------------------------------------------
+@bp.get("/entities")
+def list_entity_types_route():
+    conn = get_conn()
+    return jsonify([_type_to_payload(t) for t in list_entity_types(conn)])
+
+
+@bp.post("/entities")
+def create_entity_type():
+    conn = get_conn()
+    payload = request.get_json(silent=True) or {}
+    try:
+        td = EntityTypeDef.model_validate(payload)
+    except (ValidationError, ValueError) as exc:
+        return _client_error(str(exc))
+
+    if get_entity_type(conn, td.slug) is not None:
+        return _client_error(f"entity_type {td.slug!r} already exists", status=409)
+    try:
+        saved = upsert_entity_type(conn, td)
+    except sqlite3.IntegrityError as exc:
+        return _client_error(str(exc), status=409)
+    return jsonify(_type_to_payload(saved)), 201
+
+
+@bp.get("/entities/<slug>")
+def get_entity_type_route(slug: str):
+    conn = get_conn()
+    td = get_entity_type(conn, slug)
+    if td is None:
+        return _client_error("not found", status=404)
+    return jsonify(_type_to_payload(td))
+
+
+@bp.put("/entities/<slug>")
+def replace_entity_type(slug: str):
+    conn = get_conn()
+    if get_entity_type(conn, slug) is None:
+        return _client_error("not found", status=404)
+    payload = request.get_json(silent=True) or {}
+    payload["slug"] = slug
+    try:
+        td = EntityTypeDef.model_validate(payload)
+    except (ValidationError, ValueError) as exc:
+        return _client_error(str(exc))
+    saved = upsert_entity_type(conn, td)
+    return jsonify(_type_to_payload(saved))
+
+
+@bp.delete("/entities/<slug>")
+def delete_entity_type_route(slug: str):
+    conn = get_conn()
+    existing = get_entity_type(conn, slug)
+    if existing is None:
+        return _client_error("not found", status=404)
+    if existing.is_builtin:
+        return _client_error("built-in types cannot be deleted", status=409)
+    try:
+        delete_entity_type(conn, slug)
+    except sqlite3.IntegrityError as exc:
+        # FK RESTRICT from `entities.type_slug` once Stage 2 lands.
+        return _client_error(f"type still has instances: {exc}", status=409)
+    return ("", 204)
+
+
+# ---------------------------------------------------------------------------
+# Relation types
+# ---------------------------------------------------------------------------
+@bp.get("/relations")
+def list_relation_types_route():
+    conn = get_conn()
+    return jsonify([_type_to_payload(t) for t in list_relation_types(conn)])
+
+
+@bp.post("/relations")
+def create_relation_type():
+    conn = get_conn()
+    payload = request.get_json(silent=True) or {}
+    try:
+        td = RelationTypeDef.model_validate(payload)
+    except (ValidationError, ValueError) as exc:
+        return _client_error(str(exc))
+
+    if get_relation_type(conn, td.slug) is not None:
+        return _client_error(f"relation_type {td.slug!r} already exists", status=409)
+    try:
+        saved = upsert_relation_type(conn, td)
+    except sqlite3.IntegrityError as exc:
+        return _client_error(str(exc), status=409)
+    return jsonify(_type_to_payload(saved)), 201
+
+
+@bp.get("/relations/<slug>")
+def get_relation_type_route(slug: str):
+    conn = get_conn()
+    td = get_relation_type(conn, slug)
+    if td is None:
+        return _client_error("not found", status=404)
+    return jsonify(_type_to_payload(td))
+
+
+@bp.put("/relations/<slug>")
+def replace_relation_type(slug: str):
+    conn = get_conn()
+    if get_relation_type(conn, slug) is None:
+        return _client_error("not found", status=404)
+    payload = request.get_json(silent=True) or {}
+    payload["slug"] = slug
+    try:
+        td = RelationTypeDef.model_validate(payload)
+    except (ValidationError, ValueError) as exc:
+        return _client_error(str(exc))
+    saved = upsert_relation_type(conn, td)
+    return jsonify(_type_to_payload(saved))
+
+
+@bp.delete("/relations/<slug>")
+def delete_relation_type_route(slug: str):
+    conn = get_conn()
+    existing = get_relation_type(conn, slug)
+    if existing is None:
+        return _client_error("not found", status=404)
+    if existing.is_builtin:
+        return _client_error("built-in types cannot be deleted", status=409)
+    try:
+        delete_relation_type(conn, slug)
+    except sqlite3.IntegrityError as exc:
+        return _client_error(f"type still has instances: {exc}", status=409)
+    return ("", 204)

--- a/tests/docdb/test_field_spec.py
+++ b/tests/docdb/test_field_spec.py
@@ -1,0 +1,149 @@
+"""FieldSpec parsing, validation, and dynamic-model generation tests."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from docdb.typing.field_spec import (
+    FieldSpec,
+    build_dynamic_model,
+    parse_fields_schema,
+    validate_fields,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_fields_schema
+# ---------------------------------------------------------------------------
+class TestParseFieldsSchema:
+    def test_parses_empty_array(self) -> None:
+        assert parse_fields_schema("[]") == []
+
+    def test_parses_known_types(self) -> None:
+        raw = """[
+          {"name":"title","label":"Title","type":"string"},
+          {"name":"status","label":"Status","type":"enum","required":true,
+           "options":["a","b"],"default":"a"},
+          {"name":"due","label":"Due","type":"date"}
+        ]"""
+        specs = parse_fields_schema(raw)
+        assert [s.name for s in specs] == ["title", "status", "due"]
+        assert [s.type for s in specs] == ["string", "enum", "date"]
+        # The enum spec carries options
+        enum_spec = specs[1]
+        assert getattr(enum_spec, "options", None) == ["a", "b"]
+
+    def test_rejects_missing_options_for_enum(self) -> None:
+        raw = '[{"name":"s","label":"S","type":"enum"}]'
+        with pytest.raises(ValidationError):
+            parse_fields_schema(raw)
+
+    def test_rejects_duplicate_field_names(self) -> None:
+        raw = """[
+          {"name":"x","label":"X","type":"string"},
+          {"name":"x","label":"X2","type":"int"}
+        ]"""
+        with pytest.raises(ValueError):
+            parse_fields_schema(raw)
+
+    def test_rejects_non_snake_case_name(self) -> None:
+        # Field names must be JSON-key safe and stable. We reject anything
+        # that isn't a python identifier-style slug.
+        raw = '[{"name":"With Space","label":"x","type":"string"}]'
+        with pytest.raises(ValidationError):
+            parse_fields_schema(raw)
+
+
+# ---------------------------------------------------------------------------
+# validate_fields (semantic)
+# ---------------------------------------------------------------------------
+class TestValidateFields:
+    @pytest.fixture
+    def task_specs(self) -> list[FieldSpec]:
+        return parse_fields_schema(
+            """[
+              {"name":"status","label":"Status","type":"enum","required":true,
+               "options":["pending","done"],"default":"pending"},
+              {"name":"priority","label":"P","type":"enum","required":false,
+               "options":["high","low"]},
+              {"name":"due","label":"Due","type":"date","required":false}
+            ]"""
+        )
+
+    def test_accepts_valid_payload(self, task_specs: list[FieldSpec]) -> None:
+        out = validate_fields(task_specs, {"status": "done", "priority": "high", "due": "2026-05-20"})
+        assert out == {"status": "done", "priority": "high", "due": "2026-05-20"}
+
+    def test_fills_default_for_missing_required_enum(self, task_specs: list[FieldSpec]) -> None:
+        out = validate_fields(task_specs, {})
+        assert out["status"] == "pending"
+
+    def test_rejects_unknown_enum_value(self, task_specs: list[FieldSpec]) -> None:
+        with pytest.raises(ValueError):
+            validate_fields(task_specs, {"status": "bogus"})
+
+    def test_drops_unknown_field(self, task_specs: list[FieldSpec]) -> None:
+        out = validate_fields(task_specs, {"status": "pending", "extraneous": "x"})
+        assert "extraneous" not in out
+
+    def test_coerces_empty_string_to_none_for_optional(self, task_specs: list[FieldSpec]) -> None:
+        out = validate_fields(task_specs, {"due": ""})
+        assert out.get("due") is None
+
+    def test_rejects_malformed_date(self, task_specs: list[FieldSpec]) -> None:
+        with pytest.raises(ValueError):
+            validate_fields(task_specs, {"due": "not-a-date"})
+
+
+# ---------------------------------------------------------------------------
+# build_dynamic_model
+# ---------------------------------------------------------------------------
+class TestBuildDynamicModel:
+    def test_round_trips_minimal_payload(self) -> None:
+        specs = parse_fields_schema('[{"name":"x","label":"X","type":"string"}]')
+        Model = build_dynamic_model("EntityFieldsTest1", specs)
+        obj = Model(x="hello")
+        assert obj.x == "hello"  # type: ignore[attr-defined]
+
+    def test_enum_field_rejects_invalid_option(self) -> None:
+        specs = parse_fields_schema(
+            '[{"name":"s","label":"S","type":"enum","required":true,"options":["a","b"]}]'
+        )
+        Model = build_dynamic_model("EntityFieldsTest2", specs)
+        with pytest.raises(ValidationError):
+            Model(s="c")
+
+    def test_optional_field_defaults_to_none(self) -> None:
+        specs = parse_fields_schema('[{"name":"y","label":"Y","type":"int","required":false}]')
+        Model = build_dynamic_model("EntityFieldsTest3", specs)
+        obj = Model()
+        assert obj.y is None  # type: ignore[attr-defined]
+
+    def test_each_primitive_type_round_trips(self) -> None:
+        # Exhaustive matrix across the seven non-enum primitives.
+        cases = [
+            ("string", "abc"),
+            ("text", "long\nstring"),
+            ("int", 7),
+            ("float", 1.5),
+            ("bool", True),
+            ("date", "2026-05-20"),
+            ("datetime", "2026-05-20T12:00:00Z"),
+            ("url", "https://example.com"),
+        ]
+        for kind, value in cases:
+            specs = parse_fields_schema(
+                f'[{{"name":"f","label":"F","type":"{kind}","required":true}}]'
+            )
+            Model = build_dynamic_model(f"EntityFieldsPrim_{kind}", specs)
+            obj = Model(f=value)
+            assert obj.f == value  # type: ignore[attr-defined]
+
+    def test_ref_field_accepts_entity_id(self) -> None:
+        specs = parse_fields_schema(
+            '[{"name":"owner","label":"Owner","type":"ref","ref_type_slug":"person"}]'
+        )
+        Model = build_dynamic_model("EntityFieldsRef", specs)
+        obj = Model(owner="ent-abcdef012345")
+        assert obj.owner == "ent-abcdef012345"  # type: ignore[attr-defined]

--- a/tests/docdb/test_registry.py
+++ b/tests/docdb/test_registry.py
@@ -1,0 +1,150 @@
+"""Type registry tests: round-tripping rows, hashing for cache invalidation."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from docdb.typing.registry import (
+    EntityTypeDef,
+    RelationTypeDef,
+    delete_entity_type,
+    delete_relation_type,
+    get_entity_type,
+    get_relation_type,
+    list_entity_types,
+    list_relation_types,
+    registry_hash,
+    upsert_entity_type,
+    upsert_relation_type,
+)
+
+
+def test_seed_entity_types_loaded_after_init_db(conn: sqlite3.Connection) -> None:
+    slugs = {t.slug for t in list_entity_types(conn)}
+    assert {"person", "org", "place", "task"}.issubset(slugs)
+
+
+def test_seed_task_has_three_fields(conn: sqlite3.Connection) -> None:
+    task = get_entity_type(conn, "task")
+    assert task is not None
+    assert [f.name for f in task.fields] == ["status", "priority", "due_date"]
+    statuses = next(f for f in task.fields if f.name == "status")
+    assert getattr(statuses, "options", None) == ["pending", "in_progress", "completed", "cancelled"]
+
+
+def test_seed_relation_types_loaded(conn: sqlite3.Connection) -> None:
+    slugs = {t.slug for t in list_relation_types(conn)}
+    assert {"assigned_to", "mentions"}.issubset(slugs)
+
+
+class TestUpsertEntityType:
+    def test_creates_and_reads_back(self, conn: sqlite3.Connection) -> None:
+        upsert_entity_type(
+            conn,
+            EntityTypeDef.model_validate(
+                {
+                    "slug": "meeting_topic",
+                    "label": "議題",
+                    "description": "会議で議論されたトピック",
+                    "fields_schema": [
+                        {"name": "decision", "label": "決定事項", "type": "text", "required": False}
+                    ],
+                    "extraction_hint": "会議メモから議題を抽出",
+                }
+            ),
+        )
+        got = get_entity_type(conn, "meeting_topic")
+        assert got is not None
+        assert got.label == "議題"
+        assert [f.name for f in got.fields] == ["decision"]
+
+    def test_rejects_invalid_fields_schema(self, conn: sqlite3.Connection) -> None:
+        # Duplicate field names: should raise during parse, not silently corrupt DB.
+        with pytest.raises(ValueError):
+            EntityTypeDef.model_validate(
+                {
+                    "slug": "bogus",
+                    "label": "bogus",
+                    "fields_schema": [
+                        {"name": "x", "label": "X", "type": "string"},
+                        {"name": "x", "label": "X2", "type": "int"},
+                    ],
+                }
+            )
+
+    def test_updates_existing_row(self, conn: sqlite3.Connection) -> None:
+        upsert_entity_type(
+            conn,
+            EntityTypeDef.model_validate(
+                {"slug": "decision", "label": "決定", "fields_schema": []}
+            ),
+        )
+        upsert_entity_type(
+            conn,
+            EntityTypeDef.model_validate(
+                {"slug": "decision", "label": "Decisions", "fields_schema": []}
+            ),
+        )
+        got = get_entity_type(conn, "decision")
+        assert got is not None
+        assert got.label == "Decisions"
+
+    def test_delete_removes_row(self, conn: sqlite3.Connection) -> None:
+        upsert_entity_type(
+            conn,
+            EntityTypeDef.model_validate(
+                {"slug": "temp", "label": "tmp", "fields_schema": []}
+            ),
+        )
+        deleted = delete_entity_type(conn, "temp")
+        assert deleted is True
+        assert get_entity_type(conn, "temp") is None
+
+
+class TestRelationTypes:
+    def test_upsert_and_get(self, conn: sqlite3.Connection) -> None:
+        upsert_relation_type(
+            conn,
+            RelationTypeDef.model_validate(
+                {
+                    "slug": "blocks",
+                    "label": "ブロックする",
+                    "source_type_slug": "task",
+                    "target_type_slug": "task",
+                    "fields_schema": [],
+                }
+            ),
+        )
+        got = get_relation_type(conn, "blocks")
+        assert got is not None
+        assert got.source_type_slug == "task"
+        assert got.target_type_slug == "task"
+
+    def test_delete(self, conn: sqlite3.Connection) -> None:
+        upsert_relation_type(
+            conn,
+            RelationTypeDef.model_validate(
+                {"slug": "tmp_rel", "label": "tmp", "fields_schema": []}
+            ),
+        )
+        assert delete_relation_type(conn, "tmp_rel") is True
+        assert get_relation_type(conn, "tmp_rel") is None
+
+
+class TestRegistryHash:
+    def test_changes_when_an_entity_type_is_updated(self, conn: sqlite3.Connection) -> None:
+        before = registry_hash(conn)
+        upsert_entity_type(
+            conn,
+            EntityTypeDef.model_validate(
+                {"slug": "person", "label": "Person (renamed)", "fields_schema": []}
+            ),
+        )
+        after = registry_hash(conn)
+        assert before != after
+
+    def test_stable_when_nothing_changes(self, conn: sqlite3.Connection) -> None:
+        assert registry_hash(conn) == registry_hash(conn)

--- a/tests/docdb/test_schema.py
+++ b/tests/docdb/test_schema.py
@@ -20,6 +20,8 @@ EXPECTED_TABLES = {
     "schema_version",
     "documents",
     "entities",
+    "entity_types",
+    "relation_types",
     "tags",
     "document_entities",
     "document_tags",
@@ -45,7 +47,7 @@ def test_init_db_creates_every_expected_table(conn: sqlite3.Connection) -> None:
 def test_schema_version_row_is_recorded(conn: sqlite3.Connection) -> None:
     row = conn.execute("SELECT version FROM schema_version ORDER BY version DESC LIMIT 1").fetchone()
     assert row is not None
-    assert row["version"] == 1
+    assert row["version"] == 2
 
 
 def test_init_db_is_idempotent(db_path) -> None:

--- a/tests/server/test_types_routes.py
+++ b/tests/server/test_types_routes.py
@@ -1,0 +1,137 @@
+"""HTTP-level tests for the type registry CRUD endpoints."""
+
+from __future__ import annotations
+
+
+def test_list_entity_types_includes_seeds(client) -> None:
+    res = client.get("/api/types/entities")
+    assert res.status_code == 200
+    body = res.get_json()
+    slugs = {t["slug"] for t in body}
+    assert {"person", "org", "place", "task"}.issubset(slugs)
+
+
+def test_task_seed_carries_field_schema(client) -> None:
+    res = client.get("/api/types/entities/task")
+    assert res.status_code == 200
+    body = res.get_json()
+    field_names = [f["name"] for f in body["fields_schema"]]
+    assert field_names == ["status", "priority", "due_date"]
+    assert body["is_builtin"] is True
+
+
+def test_get_unknown_returns_404(client) -> None:
+    res = client.get("/api/types/entities/no-such-type")
+    assert res.status_code == 404
+
+
+def test_create_then_get(client) -> None:
+    payload = {
+        "slug": "decision",
+        "label": "決定",
+        "description": "会議で下された決定事項",
+        "fields_schema": [
+            {"name": "owner", "label": "Owner", "type": "ref", "ref_type_slug": "person"},
+        ],
+        "extraction_hint": "「決まった」「決定」などの文末を手掛かりに抽出",
+    }
+    res = client.post("/api/types/entities", json=payload)
+    assert res.status_code == 201
+    created = res.get_json()
+    assert created["slug"] == "decision"
+    assert created["is_builtin"] is False
+
+    res = client.get("/api/types/entities/decision")
+    assert res.status_code == 200
+
+
+def test_create_with_invalid_field_spec_is_400(client) -> None:
+    res = client.post(
+        "/api/types/entities",
+        json={
+            "slug": "broken",
+            "label": "broken",
+            "fields_schema": [
+                {"name": "needs options", "label": "x", "type": "enum"},
+            ],
+        },
+    )
+    assert res.status_code == 400
+
+
+def test_create_duplicate_slug_is_409(client) -> None:
+    res = client.post(
+        "/api/types/entities",
+        json={"slug": "person", "label": "duplicate", "fields_schema": []},
+    )
+    assert res.status_code == 409
+
+
+def test_put_updates_existing(client) -> None:
+    res = client.post(
+        "/api/types/entities",
+        json={"slug": "ticket", "label": "チケット", "fields_schema": []},
+    )
+    assert res.status_code == 201
+
+    res = client.put(
+        "/api/types/entities/ticket",
+        json={"label": "Ticket (renamed)", "fields_schema": []},
+    )
+    assert res.status_code == 200
+    assert res.get_json()["label"] == "Ticket (renamed)"
+
+
+def test_put_unknown_returns_404(client) -> None:
+    res = client.put(
+        "/api/types/entities/ghost",
+        json={"label": "ghost", "fields_schema": []},
+    )
+    assert res.status_code == 404
+
+
+def test_delete_user_type(client) -> None:
+    client.post(
+        "/api/types/entities",
+        json={"slug": "tmp_type", "label": "tmp", "fields_schema": []},
+    )
+    res = client.delete("/api/types/entities/tmp_type")
+    assert res.status_code == 204
+    assert client.get("/api/types/entities/tmp_type").status_code == 404
+
+
+def test_delete_builtin_is_409(client) -> None:
+    res = client.delete("/api/types/entities/person")
+    assert res.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Relation types
+# ---------------------------------------------------------------------------
+def test_list_relation_types_includes_seeds(client) -> None:
+    res = client.get("/api/types/relations")
+    assert res.status_code == 200
+    slugs = {t["slug"] for t in res.get_json()}
+    assert {"assigned_to", "mentions"}.issubset(slugs)
+
+
+def test_create_relation_type(client) -> None:
+    res = client.post(
+        "/api/types/relations",
+        json={
+            "slug": "blocks",
+            "label": "ブロックする",
+            "source_type_slug": "task",
+            "target_type_slug": "task",
+            "fields_schema": [],
+        },
+    )
+    assert res.status_code == 201
+    body = res.get_json()
+    assert body["source_type_slug"] == "task"
+    assert body["target_type_slug"] == "task"
+
+
+def test_delete_builtin_relation_is_409(client) -> None:
+    res = client.delete("/api/types/relations/mentions")
+    assert res.status_code == 409


### PR DESCRIPTION
Lays the foundation for the property-graph redesign: user-definable entity types and relation types are now first-class rows in the database, with a FieldSpec-based schema-of-schema and CRUD endpoints.

- schema.sql: entity_types / relation_types tables coexist with the legacy entities/todos tables; bumped schema_version to 2.
- seed.sql: ships built-in person / org / place / task entity types plus assigned_to / mentions relation types. Task carries the status / priority / due_date FieldSpec equivalent to today's todos shape.
- docdb.typing.field_spec: 10-primitive discriminated union with semantic validation and dynamic Pydantic model construction (for Stage 3 LLM use).
- docdb.typing.registry: row codecs, CRUD, and registry_hash for cache busting.
- server.routes.types: /api/types/{entities,relations} full CRUD; rejects deletion of built-ins and surfaces 400 / 404 / 409 errors cleanly.
- Settings.tsx: read-only dashboard at /settings showing every registered type, its fields, and its LLM extraction hint. Edit UI lands in Stage 4.

40 new tests; full suite 273 passed.