### PR TITLE
feat(extraction): rebuild LLM extraction on the runtime type registry…

### DIFF
--- a/src/docdb/config.py
+++ b/src/docdb/config.py
@@ -28,6 +28,13 @@ class Settings(BaseSettings):
     agent_max_iters: int = Field(default=8, ge=1, le=20)
     sql_max_limit: int = Field(default=100, ge=1, le=1000)
 
+    # Stage 3 — LLM extraction tuning.
+    # Relation extraction is more error-prone than entity extraction on
+    # small Ollama models; this flag lets the user turn it off without
+    # rebuilding the type registry.
+    extract_relations: bool = True
+    extraction_prompt_max_bytes: int = Field(default=30_000, ge=2_000, le=200_000)
+
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/src/docdb/ingestion/extractor.py
+++ b/src/docdb/ingestion/extractor.py
@@ -1,8 +1,11 @@
 """LLM-driven metadata extraction.
 
 Takes a ``ParsedDocument`` and asks an ``LLMProtocol`` to fill an
-``ExtractionResult``. The schema lives in ``docdb.models`` and is what
-instructor will request from the underlying model.
+``ExtractionResult``. Stage 3 makes both the system prompt and the
+Pydantic schema dynamic: at construction time the extractor receives the
+runtime entity/relation type registry plus its hash, builds the
+schema-aware system prompt and the dynamic Pydantic class, and reuses
+both for every call.
 
 The extractor is intentionally thin:
     * one LLM call per document (a single document = one ingestion unit)
@@ -10,20 +13,23 @@ The extractor is intentionally thin:
     * recovery: on any LLM error, return an empty ``ExtractionResult``
       together with the error message in ``last_error`` so the pipeline
       can still write the raw document without losing the source
-
-That last point matters: if the LLM is unavailable, the ingestion
-pipeline degrades to "raw text + embedding only" rather than failing
-the whole ingest.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pydantic import BaseModel
+
 from docdb.ingestion.parser import ParsedDocument
 from docdb.llm.base import LLMProtocol
-from docdb.llm.prompts import build_extraction_user_prompt
+from docdb.llm.prompts import (
+    build_extraction_system_prompt,
+    build_extraction_user_prompt,
+)
 from docdb.models import ExtractionResult
+from docdb.typing.dynamic_model import build_extraction_model
+from docdb.typing.registry import EntityTypeDef, RelationTypeDef
 
 
 @dataclass
@@ -43,19 +49,45 @@ class Extractor:
         llm: LLMProtocol,
         *,
         max_input_chars: int = 8000,
+        entity_types: list[EntityTypeDef] | None = None,
+        relation_types: list[RelationTypeDef] | None = None,
+        registry_hash: str = "",
     ) -> None:
         self.llm = llm
         self.max_input_chars = max_input_chars
+        self.entity_types: list[EntityTypeDef] = list(entity_types or [])
+        self.relation_types: list[RelationTypeDef] = list(relation_types or [])
+        self._registry_hash = registry_hash
+        self._system_prompt = build_extraction_system_prompt(
+            self.entity_types, self.relation_types
+        )
+        entity_slugs = [t.slug for t in self.entity_types]
+        relation_slugs = [t.slug for t in self.relation_types]
+        self._schema_class: type[BaseModel] = build_extraction_model(
+            entity_type_slugs=entity_slugs,
+            relation_type_slugs=relation_slugs,
+            registry_hash=registry_hash or "static",
+        )
+
+    @property
+    def schema_class(self) -> type[BaseModel]:
+        return self._schema_class
+
+    @property
+    def system_prompt(self) -> str:
+        return self._system_prompt
 
     def extract(self, parsed: ParsedDocument) -> ExtractionOutcome:
         prompt = build_extraction_user_prompt(
-            parsed, max_body_chars=self.max_input_chars
+            parsed,
+            max_body_chars=self.max_input_chars,
+            system_prompt=self._system_prompt,
         )
         try:
-            result = self.llm.extract(prompt, ExtractionResult)
+            result = self.llm.extract(prompt, self._schema_class)
         except Exception as exc:  # noqa: BLE001 — graceful degradation
             return ExtractionOutcome(
-                result=ExtractionResult(
+                result=self._schema_class(  # type: ignore[call-arg]
                     title=parsed.title or "",
                     summary="",
                 ),
@@ -63,8 +95,6 @@ class Extractor:
                 error=f"{type(exc).__name__}: {exc}",
             )
 
-        # Fill blanks from the parsed document so we never lose the
-        # original title when the LLM omits it.
-        if not result.title and parsed.title:
-            result.title = parsed.title
+        if not getattr(result, "title", None) and parsed.title:
+            result.title = parsed.title  # type: ignore[assignment]
         return ExtractionOutcome(result=result, prompt=prompt)

--- a/src/docdb/ingestion/normalizer.py
+++ b/src/docdb/ingestion/normalizer.py
@@ -1,9 +1,20 @@
-"""Pure functions that turn an ``ExtractionResult`` into storage-shape rows.
+"""Turn an ``ExtractionResult`` (possibly dynamic, post-Stage-3) into
+storage-shape rows.
 
-Stage 2 trimmed this module down to tag normalisation only. Entity and
-relation normalisation moves to Stage 3, where the LLM extraction layer
-is rebuilt around the runtime type registry. Until that lands, the
-ingestion pipeline writes only document rows + tags (plus embeddings).
+Three concerns live here:
+
+* canonicalise entity / tag names so case- and width-variants of the
+  same thing collapse to one row (NFKC + strip; lowercase for tags);
+* derive deterministic IDs (``entity_id_for`` / ``tag_id_for`` /
+  ``relation_id_for``) so re-ingesting the same document is idempotent;
+* drop the LLM's hallucinations: entities whose ``type`` is not in the
+  registry, and relations whose ``source`` / ``target`` cannot be
+  resolved to an entity also produced for this document.
+
+Field-value validation against the entity_type's ``fields_schema`` is
+NOT done here — it happens at write time in
+``DocumentStore.upsert_entity`` so a single source of truth governs
+both human-authored creates and LLM-emitted writes.
 
 Everything in this module is pure: no LLM, no DB, no network.
 """
@@ -14,10 +25,15 @@ import re
 import unicodedata
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
+from typing import Any, Iterable
 
 from docdb.models import (
+    Entity,
     ExtractionResult,
+    Relation,
     Tag,
+    entity_id_for,
+    relation_id_for,
     tag_id_for,
 )
 
@@ -25,6 +41,21 @@ from docdb.models import (
 # ---------------------------------------------------------------------------
 # Link rows (pre-DB shape)
 # ---------------------------------------------------------------------------
+@dataclass
+class DocumentEntityLink:
+    document_id: str
+    entity_id: str
+    mention_count: int = 1
+    contexts: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DocumentRelationLink:
+    document_id: str
+    relation_id: str
+    contexts: list[str] = field(default_factory=list)
+
+
 @dataclass
 class DocumentTagLink:
     document_id: str
@@ -34,25 +65,43 @@ class DocumentTagLink:
 
 
 @dataclass
+class NormalizationDrop:
+    kind: str  # 'unknown_entity_type' | 'unresolved_relation' | 'invalid_relation_type'
+    reason: str
+
+
+@dataclass
 class NormalizedExtraction:
+    entities: list[Entity] = field(default_factory=list)
+    relations: list[Relation] = field(default_factory=list)
     tags: list[Tag] = field(default_factory=list)
+    entity_links: list[DocumentEntityLink] = field(default_factory=list)
+    relation_links: list[DocumentRelationLink] = field(default_factory=list)
     tag_links: list[DocumentTagLink] = field(default_factory=list)
+    drops: list[NormalizationDrop] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
 # Canonicalisation
 # ---------------------------------------------------------------------------
 def canonicalize_entity_name(name: str) -> str:
-    """NFKC + strip. Case is preserved (proper-noun-friendly).
-
-    Still exported because Stage 3's entity normaliser will reuse it.
-    """
     return unicodedata.normalize("NFKC", name).strip()
 
 
 def canonicalize_tag_name(name: str) -> str:
-    """NFKC + lower + strip. Tags are case-insensitive identifiers."""
     return unicodedata.normalize("NFKC", name).strip().lower()
+
+
+def _dedup_aliases(seq: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for s in seq:
+        key = canonicalize_entity_name(s).lower()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        out.append(canonicalize_entity_name(s))
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -62,9 +111,208 @@ def normalize_extraction(
     extraction: ExtractionResult,
     *,
     document_id: str,
+    entity_type_slugs: Iterable[str] | None = None,
+    relation_type_slugs: Iterable[str] | None = None,
+    extract_relations: bool = True,
 ) -> NormalizedExtraction:
+    """Project ``extraction`` to storage-shape rows for ``document_id``.
+
+    ``entity_type_slugs`` / ``relation_type_slugs`` come from the registry.
+    When None, the normaliser keeps every emitted entity / relation (used
+    by tests with hand-built ExtractionResult instances).
+    """
+    entity_slugs = set(entity_type_slugs) if entity_type_slugs is not None else None
+    relation_slugs = set(relation_type_slugs) if relation_type_slugs is not None else None
+
     tags, tag_links = _build_tags(extraction.tags, document_id)
-    return NormalizedExtraction(tags=tags, tag_links=tag_links)
+
+    raw_entities = list(getattr(extraction, "entities", []) or [])
+    entities, entity_links, entity_index, entity_drops = _build_entities(
+        raw_entities, document_id, entity_slugs
+    )
+
+    relations: list[Relation] = []
+    relation_links: list[DocumentRelationLink] = []
+    relation_drops: list[NormalizationDrop] = []
+    if extract_relations:
+        raw_relations = list(getattr(extraction, "relations", []) or [])
+        relations, relation_links, relation_drops = _build_relations(
+            raw_relations, document_id, entity_index, relation_slugs
+        )
+
+    return NormalizedExtraction(
+        entities=entities,
+        relations=relations,
+        tags=tags,
+        entity_links=entity_links,
+        relation_links=relation_links,
+        tag_links=tag_links,
+        drops=entity_drops + relation_drops,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entities
+# ---------------------------------------------------------------------------
+def _build_entities(
+    extracted: list[Any],
+    document_id: str,
+    entity_slugs: set[str] | None,
+) -> tuple[
+    list[Entity],
+    list[DocumentEntityLink],
+    dict[tuple[str, str], str],
+    list[NormalizationDrop],
+]:
+    """Group, canonicalise, dedup, and assign IDs to extracted entities.
+
+    Returns (entities, links, index, drops). ``index`` maps
+    (type_slug, lowercased canonical name) → entity_id so the relation
+    builder can resolve LLM-emitted ``source`` / ``target`` refs.
+    """
+    drops: list[NormalizationDrop] = []
+    grouped: dict[tuple[str, str], dict] = {}
+
+    for ex in extracted:
+        type_slug = _safe_attr(ex, "type")
+        name = _safe_attr(ex, "name")
+        if not type_slug or not name:
+            continue
+        if entity_slugs is not None and type_slug not in entity_slugs:
+            drops.append(
+                NormalizationDrop(
+                    kind="unknown_entity_type",
+                    reason=f"type={type_slug!r} name={name!r}",
+                )
+            )
+            continue
+
+        canonical = canonicalize_entity_name(name)
+        if not canonical:
+            continue
+        key = (type_slug, canonical.lower())
+        bucket = grouped.setdefault(
+            key,
+            {
+                "type_slug": type_slug,
+                "canonical_name": canonical,
+                "aliases": [],
+                "fields": {},
+                "mentions": 0,
+            },
+        )
+        bucket["mentions"] += 1
+        if name != canonical:
+            bucket["aliases"].append(name)
+        for alias in _safe_attr(ex, "aliases", []) or []:
+            bucket["aliases"].append(alias)
+
+        # First non-empty fields payload wins. The store layer validates it.
+        payload_fields = _safe_attr(ex, "fields", {}) or {}
+        if payload_fields and not bucket["fields"]:
+            bucket["fields"] = dict(payload_fields)
+
+    entities: list[Entity] = []
+    links: list[DocumentEntityLink] = []
+    index: dict[tuple[str, str], str] = {}
+    for bucket in grouped.values():
+        canonical = bucket["canonical_name"]
+        type_slug = bucket["type_slug"]
+        eid = entity_id_for(type_slug, canonical)
+        entities.append(
+            Entity(
+                id=eid,
+                type_slug=type_slug,
+                canonical_name=canonical,
+                aliases=_dedup_aliases(bucket["aliases"]),
+                fields=bucket["fields"],
+            )
+        )
+        links.append(
+            DocumentEntityLink(
+                document_id=document_id,
+                entity_id=eid,
+                mention_count=bucket["mentions"],
+            )
+        )
+        index[(type_slug, canonical.lower())] = eid
+    return entities, links, index, drops
+
+
+# ---------------------------------------------------------------------------
+# Relations
+# ---------------------------------------------------------------------------
+def _build_relations(
+    extracted: list[Any],
+    document_id: str,
+    entity_index: dict[tuple[str, str], str],
+    relation_slugs: set[str] | None,
+) -> tuple[list[Relation], list[DocumentRelationLink], list[NormalizationDrop]]:
+    """Resolve and dedup extracted relations.
+
+    Each relation must point at entities also extracted for this document
+    (the registry doesn't help us here — the LLM might mention an entity
+    that doesn't appear in this corpus). Unresolved refs land as ``drops``.
+    """
+    drops: list[NormalizationDrop] = []
+    seen: set[str] = set()
+    relations: list[Relation] = []
+    links: list[DocumentRelationLink] = []
+
+    for ex in extracted:
+        type_slug = _safe_attr(ex, "type")
+        if not type_slug:
+            continue
+        if relation_slugs is not None and type_slug not in relation_slugs:
+            drops.append(
+                NormalizationDrop(
+                    kind="invalid_relation_type",
+                    reason=f"type={type_slug!r}",
+                )
+            )
+            continue
+
+        src_id = _resolve_ref(entity_index, _safe_attr(ex, "source"))
+        tgt_id = _resolve_ref(entity_index, _safe_attr(ex, "target"))
+        if not src_id or not tgt_id:
+            drops.append(
+                NormalizationDrop(
+                    kind="unresolved_relation",
+                    reason=f"type={type_slug!r} source={_safe_attr(ex, 'source')!r} target={_safe_attr(ex, 'target')!r}",
+                )
+            )
+            continue
+
+        rid = relation_id_for(type_slug, src_id, tgt_id)
+        if rid in seen:
+            continue
+        seen.add(rid)
+
+        relations.append(
+            Relation(
+                id=rid,
+                type_slug=type_slug,
+                source_entity_id=src_id,
+                target_entity_id=tgt_id,
+                fields=dict(_safe_attr(ex, "fields", {}) or {}),
+            )
+        )
+        links.append(DocumentRelationLink(document_id=document_id, relation_id=rid))
+    return relations, links, drops
+
+
+def _resolve_ref(
+    entity_index: dict[tuple[str, str], str],
+    ref: Any,
+) -> str | None:
+    if ref is None:
+        return None
+    ref_type = _safe_attr(ref, "type")
+    ref_name = _safe_attr(ref, "name")
+    if not ref_type or not ref_name:
+        return None
+    canonical = canonicalize_entity_name(ref_name).lower()
+    return entity_index.get((ref_type, canonical))
 
 
 # ---------------------------------------------------------------------------
@@ -74,8 +322,8 @@ def _build_tags(
     raw_tags: list[str],
     document_id: str,
 ) -> tuple[list[Tag], list[DocumentTagLink]]:
-    grouped: dict[str, str] = {}  # canonical → display name
-    for raw in raw_tags:
+    grouped: dict[str, str] = {}
+    for raw in raw_tags or []:
         canonical = canonicalize_tag_name(raw)
         if not canonical:
             continue
@@ -97,11 +345,20 @@ def _build_tags(
 
 
 # ---------------------------------------------------------------------------
-# Due-date heuristic (kept; reused by Stage 3's task-type deterministic extractor)
+# Helpers
 # ---------------------------------------------------------------------------
-# `\b` between a digit and a Japanese character does not behave the way
-# casual readers expect (CJK chars count as word characters in Python
-# `re`), so explicit (?<!\d)/(?!\d) is used to bound the date tokens.
+def _safe_attr(obj: Any, name: str, default: Any = None) -> Any:
+    """Read ``name`` off a Pydantic model OR a dict; fall back to default."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+# ---------------------------------------------------------------------------
+# Due-date heuristic (kept for the deterministic ``task_checkbox`` extractor)
+# ---------------------------------------------------------------------------
 _ISO_RE = re.compile(r"(?<!\d)(\d{4})[-/](\d{1,2})[-/](\d{1,2})(?!\d)")
 _DMY_RE = re.compile(r"(?<!\d)(\d{1,2})[-/](\d{1,2})[-/](\d{4})(?!\d)")
 _JP_FULL_RE = re.compile(r"(\d{4})年(\d{1,2})月(\d{1,2})日")
@@ -117,7 +374,6 @@ _RELATIVE_WORDS = {
 
 
 def extract_due_date(text: str, *, today: date | None = None) -> str | None:
-    """Best-effort YYYY-MM-DD from common Japanese / English date phrasings."""
     today = today or datetime.now().date()
 
     if m := _JP_FULL_RE.search(text):

--- a/src/docdb/ingestion/pipeline.py
+++ b/src/docdb/ingestion/pipeline.py
@@ -13,15 +13,23 @@ The pipeline guarantees:
 * **graceful degradation** — an LLM failure does not break ingestion;
   the document, its raw text, and a heuristic title still land in the
   DB and the IngestionReport carries the error message.
+
+Stage 3 reads the entity/relation type registry from the store
+connection at construction time, hands it to the ``Extractor`` to build
+the dynamic LLM schema and prompt, and merges deterministic-extractor
+output before normalisation. Field-value validation against the
+registered ``fields_schema`` runs at write time in ``DocumentStore``;
+entities whose ``fields`` fail validation are reported as
+``extraction_error`` notes on the ingestion report rather than crashing
+the run.
 """
 
 from __future__ import annotations
 
 import re
-import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable, Iterator, Literal
+from typing import Iterator, Literal
 
 from docdb.ingestion.extractor import Extractor
 from docdb.ingestion.normalizer import normalize_extraction
@@ -33,8 +41,14 @@ from docdb.models import (
     DocType,
     Language,
     SourceType,
-    content_hash_for,
     document_id_for,
+    content_hash_for,
+)
+from docdb.typing.deterministic import run_for_types
+from docdb.typing.registry import (
+    list_entity_types,
+    list_relation_types,
+    registry_hash,
 )
 
 
@@ -49,9 +63,8 @@ class IngestionReport:
     tags_added: int = 0
     error: str | None = None
     extraction_error: str | None = None  # non-fatal
-    # Stage 3 will populate this with per-type instance counts; for now
-    # ingestion intentionally writes no entities or relations.
     entities_added_by_type: dict[str, int] = field(default_factory=dict)
+    relations_added: int = 0
 
 
 @dataclass
@@ -60,10 +73,25 @@ class IngestionPipeline:
     llm: LLMProtocol
     parser: Parser = field(default_factory=Parser)
     extractor: Extractor | None = None
+    extract_relations: bool = True
 
     def __post_init__(self) -> None:
+        # The registry is read once at construction. Tests that mutate the
+        # registry mid-run should build a fresh pipeline; ingest-dir from
+        # the CLI is short-lived enough that staleness is not a concern.
+        self._entity_types = list_entity_types(self.store.conn)
+        self._relation_types = list_relation_types(self.store.conn)
+        self._registry_hash = registry_hash(self.store.conn)
+        self._entity_slugs = {t.slug for t in self._entity_types}
+        self._relation_slugs = {t.slug for t in self._relation_types}
+
         if self.extractor is None:
-            self.extractor = Extractor(self.llm)
+            self.extractor = Extractor(
+                self.llm,
+                entity_types=self._entity_types,
+                relation_types=self._relation_types,
+                registry_hash=self._registry_hash,
+            )
 
     # ------------------------------------------------------------------
     # Public entry points
@@ -124,16 +152,21 @@ class IngestionPipeline:
         outcome = self.extractor.extract(parsed)
         result = outcome.result
 
+        # Merge deterministic extractor output into the LLM-emitted entities so
+        # the normaliser's dedup logic catches duplicates without special-casing.
+        det_entities = run_for_types(parsed.raw_text, sorted(self._entity_slugs))
+        _attach_deterministic_entities(result, det_entities)
+
         doc = Document(
             id=doc_id,
             source_path=parsed.source_path,
             source_type=parsed.source_type,
             content_hash=parsed.content_hash,
-            title=result.title or parsed.title,
-            doc_type=_safe_doc_type(result.doc_type),
-            summary=result.summary,
+            title=getattr(result, "title", None) or parsed.title,
+            doc_type=_safe_doc_type(getattr(result, "doc_type", None)),
+            summary=getattr(result, "summary", "") or "",
             raw_text=parsed.raw_text,
-            language=_safe_language(result.language),
+            language=_safe_language(getattr(result, "language", None)),
             created_at=_creation_date_from_frontmatter(parsed),
             metadata={"frontmatter": parsed.frontmatter} if parsed.frontmatter else {},
         )
@@ -152,10 +185,15 @@ class IngestionPipeline:
 
         self.store.upsert_document(doc, embedding=embedding)
 
-        # Stage 2: extraction is reduced to the document header + tags.
-        # Stage 3 reinstates entity/relation extraction using the runtime
-        # type registry. Until then, ingest writes doc + tags only.
-        norm = normalize_extraction(result, document_id=doc_id)
+        norm = normalize_extraction(
+            result,
+            document_id=doc_id,
+            entity_type_slugs=self._entity_slugs or None,
+            relation_type_slugs=self._relation_slugs or None,
+            extract_relations=self.extract_relations,
+        )
+
+        # Tags
         for tag in norm.tags:
             self.store.upsert_tag(tag)
         for link in norm.tag_links:
@@ -166,12 +204,65 @@ class IngestionPipeline:
                 source=link.source,
             )
 
+        # Entities — write each through the store so field validation runs.
+        per_type_counts: dict[str, int] = {}
+        validation_errors: list[str] = []
+        accepted_entity_ids: set[str] = set()
+        for ent in norm.entities:
+            try:
+                self.store.upsert_entity(ent)
+            except ValueError as exc:
+                validation_errors.append(f"entity {ent.canonical_name!r}: {exc}")
+                continue
+            per_type_counts[ent.type_slug] = per_type_counts.get(ent.type_slug, 0) + 1
+            accepted_entity_ids.add(ent.id)
+
+        for link in norm.entity_links:
+            if link.entity_id not in accepted_entity_ids:
+                continue
+            self.store.link_document_entity(
+                link.document_id,
+                link.entity_id,
+                mention_count=link.mention_count,
+                contexts=link.contexts,
+            )
+
+        # Relations — drop ones referencing entities that didn't make it.
+        relations_added = 0
+        for rel in norm.relations:
+            if (
+                rel.source_entity_id not in accepted_entity_ids
+                or rel.target_entity_id not in accepted_entity_ids
+            ):
+                continue
+            try:
+                self.store.upsert_relation(rel)
+            except ValueError as exc:
+                validation_errors.append(f"relation {rel.id}: {exc}")
+                continue
+            relations_added += 1
+        for link in norm.relation_links:
+            self.store.link_document_relation(
+                link.document_id, link.relation_id, contexts=link.contexts
+            )
+
+        # Surface non-fatal extraction notes (validation drops + normaliser drops)
+        # on the report so the CLI / UI can show them.
+        notes: list[str] = []
+        if outcome.error:
+            notes.append(outcome.error)
+        notes.extend(validation_errors)
+        for drop in norm.drops:
+            notes.append(f"dropped {drop.kind}: {drop.reason}")
+
         return IngestionReport(
             source_path=parsed.source_path,
             status="updated" if is_update else "created",
             document_id=doc_id,
             tags_added=len(norm.tags),
-            extraction_error=outcome.error,
+            entities_added_by_type=per_type_counts,
+            relations_added=relations_added,
+            extraction_error="; ".join(notes) if notes else None,
         )
 
     # ------------------------------------------------------------------
@@ -250,3 +341,21 @@ def _embedding_text(doc: Document) -> str:
     if not parts and doc.raw_text:
         parts.append(doc.raw_text[:512])
     return "\n\n".join(parts) or (doc.id or "empty")
+
+
+def _attach_deterministic_entities(result, det_entities: list[dict]) -> None:
+    """Merge deterministic-extractor entity dicts into the LLM result.
+
+    The dynamic schema may not have an ``entities`` attribute (when no
+    entity types are registered at all). When it does, append; the
+    normaliser handles dedup by (type, canonical_name).
+    """
+    if not det_entities:
+        return
+    existing = getattr(result, "entities", None)
+    if existing is None:
+        # No entity types registered; deterministic output is useless here.
+        return
+    # ``entities`` is a list of pydantic instances. We append plain dicts
+    # because the normaliser accepts either form (_safe_attr).
+    existing.extend(det_entities)

--- a/src/docdb/llm/fake.py
+++ b/src/docdb/llm/fake.py
@@ -105,12 +105,25 @@ class FakeLLM:
         self.calls_extract.append((text, schema))
         if self.extract_responses:
             val = self.extract_responses.pop(0)
-            if not isinstance(val, schema):
-                raise TypeError(
-                    f"FakeLLM.extract scripted response is {type(val).__name__}, "
-                    f"caller asked for {schema.__name__}"
-                )
-            return val
+            if isinstance(val, schema):
+                return val
+            # Stage 3 introduces dynamic per-call ExtractionResult subclasses;
+            # tests still script the static parent. Up-cast across the
+            # parent → child boundary by round-tripping field values. We try
+            # strict validation first; if the scripted value was created via
+            # ``model_construct`` to intentionally hold invalid data (testing
+            # pipeline fallbacks), we fall back to ``model_construct`` on the
+            # target so the bad value survives the upcast.
+            if isinstance(val, BaseModel) and issubclass(schema, type(val)):
+                payload = val.model_dump()
+                try:
+                    return schema.model_validate(payload)
+                except Exception:  # noqa: BLE001 — Pydantic ValidationError, etc.
+                    return schema.model_construct(**payload)
+            raise TypeError(
+                f"FakeLLM.extract scripted response is {type(val).__name__}, "
+                f"caller asked for {schema.__name__}"
+            )
         # Fall back to a default-constructed instance (works when every
         # field has a default; otherwise this raises and signals that
         # the test forgot to script the response).

--- a/src/docdb/llm/prompts.py
+++ b/src/docdb/llm/prompts.py
@@ -9,17 +9,24 @@ corpus (personal memos, meeting notes, journal entries) is primarily
 Japanese. English content still flows through correctly — the LLM is
 told to keep canonical names in their original script.
 
-Stage 2 stripped the entity/todo extraction guidance from
-``EXTRACTION_SYSTEM`` because the LLM no longer emits those during
-ingestion; Stage 3 rebuilds extraction around the runtime type registry.
+Stage 3 makes the extraction system prompt dynamic: every registered
+entity type and relation type from the runtime registry is rendered
+into the prompt with its label, description, fields_schema summary,
+and free-form ``extraction_hint``. The base instructions
+(``EXTRACTION_SYSTEM_BASE``) stay constant; what the LLM is allowed to
+emit varies per call.
 """
 
 from __future__ import annotations
 
 from docdb.ingestion.parser import ParsedDocument
+from docdb.typing.registry import EntityTypeDef, RelationTypeDef
 
 
-EXTRACTION_SYSTEM = (
+EXTRACTION_PROMPT_MAX_BYTES = 30_000
+
+
+EXTRACTION_SYSTEM_BASE = (
     "あなたは個人ノートから構造化メタデータを抽出するアシスタントです。\n"
     "次のルールに従い、必要なフィールドだけを正確に埋めてください。\n"
     "1. `doc_type` はメモ=memo / 会議=meeting / 日記=journal / 参考資料=reference / 仕様=spec / その他=other から1つ選ぶ。\n"
@@ -30,16 +37,119 @@ EXTRACTION_SYSTEM = (
     "6. 元の文書に存在しない情報を捏造しない。確信が持てないフィールドは空欄/空配列のままにする。"
 )
 
+# Kept for backwards-compat with tests that import the symbol directly.
+EXTRACTION_SYSTEM = EXTRACTION_SYSTEM_BASE
+
+
+def build_extraction_system_prompt(
+    entity_types: list[EntityTypeDef],
+    relation_types: list[RelationTypeDef],
+    *,
+    max_bytes: int = EXTRACTION_PROMPT_MAX_BYTES,
+) -> str:
+    """Assemble the full system prompt for the current type registry.
+
+    The structure is: base rules → entity-type catalogue → relation-type
+    catalogue → closing rule. Each catalogue entry advertises the slug,
+    label, description, field summary, and the user-authored ``extraction_hint``
+    so the LLM has both a schema and a usage cue.
+
+    Hard-capped at ``max_bytes`` UTF-8 bytes; when the assembled prompt grows
+    past the cap, types are dropped from the END (preserving builtins is the
+    caller's responsibility for now — Stage 4 will add an "is_active" knob).
+    """
+    parts: list[str] = [EXTRACTION_SYSTEM_BASE, ""]
+
+    if entity_types:
+        parts.append("# 抽出できる entity 型 (slug : label)")
+        for t in entity_types:
+            parts.append(_render_entity_type(t))
+        parts.append("")
+
+    if relation_types and entity_types:
+        # Relations only make sense when at least one entity type exists.
+        parts.append("# 抽出できる relation 型 (slug : label)")
+        for t in relation_types:
+            parts.append(_render_relation_type(t))
+        parts.append("")
+
+    if entity_types:
+        parts.append(
+            "7. entities[] に登場する `type` は上記 entity 型の slug のみ。"
+            "未登録の概念は entity として出力しない。"
+        )
+        if relation_types:
+            parts.append(
+                "8. relations[] の `source` / `target` は同じドキュメントの entities[] "
+                "に出てくる (type, name) を指す。解決できないものは出力しない。"
+            )
+
+    assembled = "\n".join(parts)
+    encoded = assembled.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return assembled
+
+    # Truncate by dropping trailing type catalogue entries until we fit.
+    return _truncate_to_fit(parts, max_bytes)
+
+
+def _render_entity_type(t: EntityTypeDef) -> str:
+    head = f"- `{t.slug}` : {t.label}"
+    if t.description:
+        head += f" — {t.description}"
+    lines = [head]
+    if t.fields:
+        for f in t.fields:
+            spec = f"    * {f.name} ({f.type}"
+            if getattr(f, "required", False):
+                spec += ", required"
+            options = getattr(f, "options", None)
+            if options:
+                spec += f", options={list(options)}"
+            spec += ")"
+            lines.append(spec)
+    if t.extraction_hint:
+        lines.append(f"    ヒント: {t.extraction_hint}")
+    return "\n".join(lines)
+
+
+def _render_relation_type(t: RelationTypeDef) -> str:
+    head = f"- `{t.slug}` : {t.label}"
+    endpoints = (
+        f" ({t.source_type_slug or 'any'} → {t.target_type_slug or 'any'})"
+    )
+    head += endpoints
+    if t.description:
+        head += f" — {t.description}"
+    lines = [head]
+    if t.extraction_hint:
+        lines.append(f"    ヒント: {t.extraction_hint}")
+    return "\n".join(lines)
+
+
+def _truncate_to_fit(parts: list[str], max_bytes: int) -> str:
+    """Drop trailing prompt sections until the encoded length fits."""
+    parts = list(parts)
+    while parts:
+        out = "\n".join(parts + ["[... 型カタログを一部省略 ...]"])
+        if len(out.encode("utf-8")) <= max_bytes:
+            return out
+        parts.pop()
+    # Defensive: even the base block doesn't fit — return a clipped string.
+    fallback = EXTRACTION_SYSTEM_BASE.encode("utf-8")[: max_bytes - 64]
+    return fallback.decode("utf-8", errors="ignore") + "\n[... 省略 ...]"
+
 
 def build_extraction_user_prompt(
     parsed: ParsedDocument,
     *,
     max_body_chars: int = 8000,
+    system_prompt: str | None = None,
 ) -> str:
     """Render the document into the user-side prompt for extraction.
 
     Layout:
-        <system instructions>
+        <system instructions, registry-aware when system_prompt is supplied>
         <metadata hints from parsing>
         <document body, truncated to max_body_chars>
     """
@@ -58,10 +168,8 @@ def build_extraction_user_prompt(
         body = body[:max_body_chars]
         truncated = True
 
-    parts = [
-        EXTRACTION_SYSTEM,
-        "",
-    ]
+    header = system_prompt if system_prompt is not None else EXTRACTION_SYSTEM_BASE
+    parts = [header, ""]
     if hints:
         parts.append("# 入力メタ情報")
         parts.extend(hints)

--- a/src/docdb/typing/deterministic.py
+++ b/src/docdb/typing/deterministic.py
@@ -1,0 +1,107 @@
+"""Per-entity-type "deterministic extractors" — pure-text rules.
+
+The runtime registry now drives LLM extraction, but some entity types
+have shapes that are also recoverable by deterministic regex (e.g.
+Markdown ``- [ ]`` checkboxes for the seed ``task`` type). These
+extractors run before/after the LLM call and let an offline ingest, or
+the LLM-shy parts of a partly-LLM-driven ingest, still produce useful
+rows.
+
+How types opt in
+----------------
+
+For now, an entity type opts in by name: this module exposes a
+``DETERMINISTIC_EXTRACTORS`` mapping keyed by ``entity_types.slug``. The
+seed ``task`` type is registered out of the box. Stage 4 may add an
+explicit ``deterministic_extractor`` column / FieldSpec attribute so
+user-defined types can plug in as well.
+
+Each extractor is a callable ``(text: str) -> list[dict]`` returning
+LLM-shaped entity dicts (``{"type": slug, "name": ..., "fields": ...}``).
+The pipeline merges these into the LLM output before normalisation, so
+the normaliser's dedup logic catches duplicates without special-casing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+
+_TODO_PATTERNS: tuple[re.Pattern, ...] = (
+    re.compile(r"^\s*[-*]\s+\[ \]\s+(.+?)\s*$", re.IGNORECASE),
+    re.compile(r"\b(?:TODO|FIXME|HACK|XXX)\s*[:：]?\s*(.+?)\s*$", re.IGNORECASE),
+)
+_DONE_PATTERN = re.compile(r"^\s*[-*]\s+\[x\]\s+", re.IGNORECASE)
+
+_HIGH_PRIORITY = ("urgent", "asap", "急", "緊急", "至急")
+_LOW_PRIORITY = ("later", "後で", "将来", "いつか")
+
+_MIN_CONTENT_LEN = 3
+
+
+def task_checkbox(text: str) -> list[dict]:
+    """Extract pending ``- [ ]`` checkbox items and TODO/FIXME-marked lines.
+
+    Returns LLM-shaped entity dicts targeting the seed ``task`` type:
+    ``{"type": "task", "name": <body>, "fields": {"status": "pending",
+    "priority": <high|medium|low>}}``.
+    """
+    out: list[dict] = []
+    seen: set[str] = set()
+    for line in text.splitlines():
+        if _DONE_PATTERN.match(line):
+            continue
+        for pat in _TODO_PATTERNS:
+            match = pat.search(line)
+            if not match:
+                continue
+            content = match.group(1).strip()
+            if len(content) < _MIN_CONTENT_LEN:
+                break
+            key = content.lower()
+            if key in seen:
+                break
+            seen.add(key)
+            out.append(
+                {
+                    "type": "task",
+                    "name": content,
+                    "aliases": [],
+                    "fields": {
+                        "status": "pending",
+                        "priority": _infer_priority(content),
+                    },
+                }
+            )
+            break
+    return out
+
+
+def _infer_priority(content: str) -> str:
+    lower = content.lower()
+    if any(word in lower for word in _HIGH_PRIORITY):
+        return "high"
+    if any(word in lower for word in _LOW_PRIORITY):
+        return "low"
+    return "medium"
+
+
+DETERMINISTIC_EXTRACTORS: dict[str, Callable[[str], list[dict]]] = {
+    "task": task_checkbox,
+}
+
+
+def run_for_types(text: str, type_slugs: list[str]) -> list[dict]:
+    """Run every deterministic extractor whose slug is registered.
+
+    Called from the ingestion pipeline once per document so the union of
+    LLM-emitted and deterministic entities flows into normalisation.
+    """
+    out: list[dict] = []
+    for slug in type_slugs:
+        extractor = DETERMINISTIC_EXTRACTORS.get(slug)
+        if extractor is None:
+            continue
+        out.extend(extractor(text))
+    return out

--- a/src/docdb/typing/dynamic_model.py
+++ b/src/docdb/typing/dynamic_model.py
@@ -1,0 +1,156 @@
+"""Per-call dynamic ``ExtractionResult`` Pydantic model.
+
+The LLM extraction layer needs a concrete ``pydantic.BaseModel`` at call time
+(``instructor`` requires a class). Stage 3 keeps that contract but generates
+the class from the runtime type registry so that user-defined entity types
+and relation types appear in the LLM-facing JSON schema.
+
+Output envelope:
+
+    {
+        "doc_type": "memo",
+        "title": "...",
+        "summary": "...",
+        "language": "ja",
+        "tags": [...],
+        "entities": [
+            {"type": "task", "name": "...", "aliases": [], "fields": {...}}
+        ],
+        "relations": [                            // only when ≥1 relation type
+            {"type": "assigned_to",
+             "source": {"type": "task", "name": "..."},
+             "target": {"type": "person", "name": "..."},
+             "fields": {}}
+        ]
+    }
+
+The ``type`` slugs are constrained to a ``Literal`` of the registered slugs so
+the LLM cannot hallucinate a brand new type. Field-value validation happens
+later, in ``DocumentStore.upsert_entity`` (which knows the type's full schema).
+"""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, create_model
+
+from docdb.models import ExtractionResult
+
+
+# ---------------------------------------------------------------------------
+# LLM-facing item shapes
+# ---------------------------------------------------------------------------
+class ExtractedEntityBase(BaseModel):
+    """Common fields for every extracted entity (the ``type`` field is filled in
+    dynamically with a ``Literal`` of registered slugs)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(min_length=1)
+    aliases: list[str] = Field(default_factory=list)
+    fields: dict[str, Any] = Field(default_factory=dict)
+
+
+class ExtractedEntityRef(BaseModel):
+    """Reference used as ``source`` / ``target`` inside an ExtractedRelation."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    type: str
+    name: str
+
+
+class ExtractedRelationBase(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: ExtractedEntityRef
+    target: ExtractedEntityRef
+    fields: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+_CACHE: dict[str, type[BaseModel]] = {}
+_LOCK = Lock()
+
+
+def build_extraction_model(
+    *,
+    entity_type_slugs: list[str],
+    relation_type_slugs: list[str],
+    registry_hash: str,
+) -> type[BaseModel]:
+    """Return a dynamically-constructed Pydantic model for LLM extraction.
+
+    ``registry_hash`` keys the cache; pass the value returned by
+    ``docdb.typing.registry.registry_hash`` so callers don't have to think
+    about invalidation.
+
+    When no entity types are registered the bare ``ExtractionResult`` is
+    returned, so the LLM is asked only to extract doc-level metadata + tags.
+    """
+    if not entity_type_slugs:
+        return ExtractionResult
+
+    cached = _CACHE.get(registry_hash)
+    if cached is not None:
+        return cached
+
+    with _LOCK:
+        cached = _CACHE.get(registry_hash)
+        if cached is not None:
+            return cached
+
+        suffix = registry_hash[:8]
+        entity_literal = _literal_of(entity_type_slugs)
+
+        # ExtractedEntity_<hash> = ExtractedEntityBase + type: Literal[slugs]
+        EntityModel = create_model(  # type: ignore[call-overload]
+            f"ExtractedEntity_{suffix}",
+            __base__=ExtractedEntityBase,
+            type=(entity_literal, ...),
+        )
+
+        extras: dict[str, tuple[Any, Any]] = {
+            "entities": (list[EntityModel], Field(default_factory=list)),
+        }
+
+        if relation_type_slugs:
+            relation_literal = _literal_of(relation_type_slugs)
+            RelationModel = create_model(  # type: ignore[call-overload]
+                f"ExtractedRelation_{suffix}",
+                __base__=ExtractedRelationBase,
+                type=(relation_literal, ...),
+            )
+            extras["relations"] = (list[RelationModel], Field(default_factory=list))
+
+        ResultModel = create_model(  # type: ignore[call-overload]
+            f"ExtractionResult_{suffix}",
+            __base__=ExtractionResult,
+            **extras,
+        )
+        _CACHE[registry_hash] = ResultModel
+        return ResultModel
+
+
+def _literal_of(values: list[str]):
+    """Build a ``typing.Literal[...]`` from a runtime list of strings.
+
+    ``Literal[tuple(values)]`` is the runtime-equivalent of
+    ``Literal['a', 'b', ...]`` because ``Literal.__class_getitem__`` accepts a
+    tuple. We assume the caller has already filtered out duplicates.
+    """
+    if not values:
+        # An empty Literal would be invalid. Caller guards this case; this
+        # raise is defensive only.
+        raise ValueError("cannot build Literal from an empty list")
+    return Literal[tuple(values)]  # type: ignore[valid-type]
+
+
+def clear_cache() -> None:
+    """Reset the model cache. Useful for tests that mutate the registry."""
+    with _LOCK:
+        _CACHE.clear()

--- a/tests/docdb/test_dynamic_extraction.py
+++ b/tests/docdb/test_dynamic_extraction.py
@@ -1,0 +1,381 @@
+"""Tests for the Stage 3 dynamic-extraction surface.
+
+Covers:
+- build_extraction_model: dynamic schema includes the right ``entities`` and
+  ``relations`` shape, with type slugs constrained to a Literal.
+- build_extraction_system_prompt: every registered slug + extraction_hint
+  appears, and the 30KB cap truncates rather than crashing.
+- Normalizer + pipeline: unknown-type entities and unresolved relations are
+  dropped (with diagnostic notes); valid ones are written.
+- Deterministic task_checkbox extractor: pulls Markdown ``- [ ]`` items and
+  feeds them to the pipeline so `task` entities are created without an LLM.
+- extract_relations flag short-circuits relation writes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from docdb.ingestion.normalizer import (
+    NormalizationDrop,
+    normalize_extraction,
+)
+from docdb.ingestion.pipeline import IngestionPipeline
+from docdb.ingestion.store import DocumentStore
+from docdb.llm.fake import FakeLLM
+from docdb.llm.prompts import (
+    EXTRACTION_PROMPT_MAX_BYTES,
+    build_extraction_system_prompt,
+)
+from docdb.models import ExtractionResult, entity_id_for, relation_id_for
+from docdb.typing.deterministic import task_checkbox
+from docdb.typing.dynamic_model import build_extraction_model, clear_cache
+from docdb.typing.registry import (
+    EntityTypeDef,
+    RelationTypeDef,
+    list_entity_types,
+    list_relation_types,
+    registry_hash,
+    upsert_entity_type,
+)
+
+
+# ---------------------------------------------------------------------------
+# Dynamic Pydantic model
+# ---------------------------------------------------------------------------
+class TestBuildExtractionModel:
+    def setup_method(self) -> None:
+        clear_cache()
+
+    def test_no_entity_types_returns_bare_extraction_result(self) -> None:
+        Model = build_extraction_model(
+            entity_type_slugs=[], relation_type_slugs=[], registry_hash="empty"
+        )
+        assert Model is ExtractionResult
+
+    def test_with_entity_types_extends_result(self) -> None:
+        Model = build_extraction_model(
+            entity_type_slugs=["person", "task"],
+            relation_type_slugs=["assigned_to"],
+            registry_hash="abc123",
+        )
+        assert issubclass(Model, ExtractionResult)
+        assert "entities" in Model.model_fields
+        assert "relations" in Model.model_fields
+
+    def test_entity_type_field_is_literal_constrained(self) -> None:
+        Model = build_extraction_model(
+            entity_type_slugs=["person"],
+            relation_type_slugs=[],
+            registry_hash="lit-test",
+        )
+        # Valid slug works.
+        ok = Model(entities=[{"type": "person", "name": "Alice"}])
+        assert ok.entities[0].type == "person"  # type: ignore[attr-defined]
+        # Unknown slug raises ValidationError thanks to the Literal.
+        with pytest.raises(ValidationError):
+            Model(entities=[{"type": "alien", "name": "x"}])
+
+    def test_cache_reuses_same_class_for_same_hash(self) -> None:
+        A = build_extraction_model(
+            entity_type_slugs=["person"], relation_type_slugs=[], registry_hash="hash-A"
+        )
+        B = build_extraction_model(
+            entity_type_slugs=["person"], relation_type_slugs=[], registry_hash="hash-A"
+        )
+        assert A is B
+
+    def test_distinct_registry_hash_yields_distinct_class(self) -> None:
+        A = build_extraction_model(
+            entity_type_slugs=["person"], relation_type_slugs=[], registry_hash="hash-A"
+        )
+        B = build_extraction_model(
+            entity_type_slugs=["person"], relation_type_slugs=[], registry_hash="hash-B"
+        )
+        assert A is not B
+
+
+# ---------------------------------------------------------------------------
+# Dynamic system prompt
+# ---------------------------------------------------------------------------
+class TestBuildExtractionSystemPrompt:
+    def test_mentions_every_registered_slug(self, conn: sqlite3.Connection) -> None:
+        entity_types = list_entity_types(conn)
+        relation_types = list_relation_types(conn)
+        prompt = build_extraction_system_prompt(entity_types, relation_types)
+        for t in entity_types:
+            assert t.slug in prompt
+        for t in relation_types:
+            assert t.slug in prompt
+
+    def test_includes_extraction_hint(self, conn: sqlite3.Connection) -> None:
+        task = next(t for t in list_entity_types(conn) if t.slug == "task")
+        prompt = build_extraction_system_prompt([task], [])
+        assert task.extraction_hint is not None
+        # Some prefix of the hint should appear (it can be long).
+        assert task.extraction_hint[:20] in prompt
+
+    def test_includes_task_field_summary(self, conn: sqlite3.Connection) -> None:
+        task = next(t for t in list_entity_types(conn) if t.slug == "task")
+        prompt = build_extraction_system_prompt([task], [])
+        assert "status" in prompt
+        assert "priority" in prompt
+        assert "due_date" in prompt
+
+    def test_empty_registry_returns_base_only(self) -> None:
+        prompt = build_extraction_system_prompt([], [])
+        assert "doc_type" in prompt
+        assert "entities[]" not in prompt
+        assert "relations[]" not in prompt
+
+    def test_relation_types_are_only_shown_when_entity_types_exist(self) -> None:
+        rel = RelationTypeDef.model_validate(
+            {"slug": "assigned_to", "label": "担当", "fields_schema": []}
+        )
+        prompt = build_extraction_system_prompt([], [rel])
+        # No entity types → relations are not useful; the catalogue is skipped.
+        assert "assigned_to" not in prompt
+
+    def test_byte_cap_truncates_rather_than_crashes(self, conn: sqlite3.Connection) -> None:
+        entity_types = list_entity_types(conn)
+        relation_types = list_relation_types(conn)
+        prompt = build_extraction_system_prompt(
+            entity_types, relation_types, max_bytes=600
+        )
+        assert len(prompt.encode("utf-8")) <= 700  # cap + small truncation marker
+        assert "省略" in prompt
+
+    def test_default_cap_is_30kb(self) -> None:
+        assert EXTRACTION_PROMPT_MAX_BYTES == 30_000
+
+
+# ---------------------------------------------------------------------------
+# Normalizer: unknown-type drop + unresolved-relation drop
+# ---------------------------------------------------------------------------
+class TestNormalizerStage3:
+    def _make_payload(
+        self,
+        entities: list[dict] | None = None,
+        relations: list[dict] | None = None,
+    ) -> BaseModel:
+        Model = build_extraction_model(
+            entity_type_slugs=["person", "task"],
+            relation_type_slugs=["assigned_to"],
+            registry_hash="norm-test",
+        )
+        return Model(entities=entities or [], relations=relations or [])
+
+    def test_drops_unknown_type_entity_with_diagnostic(self) -> None:
+        # Build a "stricter-LLM-bypassed" model that allows the ghost type so
+        # we can feed it through normaliser; the normaliser must drop it because
+        # ``entity_type_slugs`` (the registry) does not include 'ghost'.
+        LooseModel = build_extraction_model(
+            entity_type_slugs=["person", "ghost"],
+            relation_type_slugs=[],
+            registry_hash="drop-test",
+        )
+        result = LooseModel(
+            entities=[
+                {"type": "person", "name": "Alice"},
+                {"type": "ghost", "name": "ナナミ"},
+            ]
+        )
+        norm = normalize_extraction(
+            result,
+            document_id="doc-1",
+            entity_type_slugs={"person", "task"},  # registry; ghost is unknown
+        )
+        assert len(norm.entities) == 1
+        assert norm.entities[0].canonical_name == "Alice"
+        assert any(d.kind == "unknown_entity_type" for d in norm.drops)
+
+    def test_resolves_relation_by_type_and_name(self) -> None:
+        payload = self._make_payload(
+            entities=[
+                {"type": "task", "name": "design review",
+                 "fields": {"status": "pending", "priority": "high"}},
+                {"type": "person", "name": "Alice"},
+            ],
+            relations=[
+                {"type": "assigned_to",
+                 "source": {"type": "task", "name": "design review"},
+                 "target": {"type": "person", "name": "Alice"}},
+            ],
+        )
+        norm = normalize_extraction(
+            payload,
+            document_id="doc-1",
+            entity_type_slugs={"person", "task"},
+            relation_type_slugs={"assigned_to"},
+        )
+        assert len(norm.relations) == 1
+        rel = norm.relations[0]
+        assert rel.source_entity_id == entity_id_for("task", "design review")
+        assert rel.target_entity_id == entity_id_for("person", "Alice")
+        # Deterministic relation id.
+        assert rel.id == relation_id_for(
+            "assigned_to", rel.source_entity_id, rel.target_entity_id
+        )
+
+    def test_drops_relation_with_unresolved_source(self) -> None:
+        payload = self._make_payload(
+            entities=[{"type": "person", "name": "Alice"}],
+            relations=[
+                {"type": "assigned_to",
+                 "source": {"type": "task", "name": "missing-task"},
+                 "target": {"type": "person", "name": "Alice"}},
+            ],
+        )
+        norm = normalize_extraction(
+            payload,
+            document_id="doc-1",
+            entity_type_slugs={"person", "task"},
+            relation_type_slugs={"assigned_to"},
+        )
+        assert norm.relations == []
+        assert any(d.kind == "unresolved_relation" for d in norm.drops)
+
+    def test_extract_relations_false_skips_relations(self) -> None:
+        payload = self._make_payload(
+            entities=[
+                {"type": "task", "name": "x", "fields": {"status": "pending", "priority": "medium"}},
+                {"type": "person", "name": "y"},
+            ],
+            relations=[
+                {"type": "assigned_to",
+                 "source": {"type": "task", "name": "x"},
+                 "target": {"type": "person", "name": "y"}},
+            ],
+        )
+        norm = normalize_extraction(
+            payload,
+            document_id="doc-1",
+            entity_type_slugs={"person", "task"},
+            relation_type_slugs={"assigned_to"},
+            extract_relations=False,
+        )
+        assert norm.entities, "entities still produced"
+        assert norm.relations == []
+
+
+# ---------------------------------------------------------------------------
+# Deterministic extractor
+# ---------------------------------------------------------------------------
+class TestTaskCheckbox:
+    def test_pulls_pending_checkbox_with_priority(self) -> None:
+        text = "- [ ] urgent: 設計レビュー\n- [x] 終わったやつ\n- [ ] 普通のタスク\n"
+        out = task_checkbox(text)
+        contents = {item["name"]: item["fields"]["priority"] for item in out}
+        assert contents == {"urgent: 設計レビュー": "high", "普通のタスク": "medium"}
+
+    def test_skips_too_short_entries(self) -> None:
+        assert task_checkbox("- [ ] ab\n") == []
+
+    def test_deduplicates_identical_bodies(self) -> None:
+        out = task_checkbox("- [ ] 同じタスク\nTODO: 同じタスク\n")
+        assert len(out) == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end pipeline integration
+# ---------------------------------------------------------------------------
+class TestPipelineStage3:
+    def test_ingest_creates_task_entity_via_deterministic_extractor(self, conn) -> None:
+        # LLM script: empty extraction. Deterministic extractor finds the TODO.
+        fake = FakeLLM(extract_responses=[ExtractionResult(title="t")])
+        pipeline = IngestionPipeline(store=DocumentStore(conn), llm=fake)
+        report = pipeline.ingest_text(
+            "# メモ\n- [ ] 緊急の設計レビュー\n",
+            source_path="memo/x.md",
+        )
+        assert report.status == "created"
+        assert report.entities_added_by_type.get("task") == 1
+
+        # The task entity exists with the deterministic priority inference.
+        row = conn.execute(
+            "SELECT canonical_name, json_extract(fields, '$.priority') AS prio "
+            "FROM entities WHERE type_slug = 'task'"
+        ).fetchone()
+        assert row["canonical_name"] == "緊急の設計レビュー"
+        assert row["prio"] == "high"
+
+    def test_pipeline_writes_relation_when_payload_resolves(self, conn) -> None:
+        Model = build_extraction_model(
+            entity_type_slugs=["person", "task"],
+            relation_type_slugs=["assigned_to"],
+            registry_hash=registry_hash(conn),
+        )
+        scripted = Model(
+            title="t",
+            entities=[
+                {"type": "task", "name": "code review",
+                 "fields": {"status": "pending", "priority": "high"}},
+                {"type": "person", "name": "Alice"},
+            ],
+            relations=[
+                {"type": "assigned_to",
+                 "source": {"type": "task", "name": "code review"},
+                 "target": {"type": "person", "name": "Alice"}},
+            ],
+        )
+        fake = FakeLLM(extract_responses=[scripted])
+        pipeline = IngestionPipeline(store=DocumentStore(conn), llm=fake)
+        report = pipeline.ingest_text("本文", source_path="memo/r.md")
+        assert report.relations_added == 1
+
+        row = conn.execute(
+            "SELECT type_slug FROM relations WHERE type_slug = 'assigned_to'"
+        ).fetchone()
+        assert row is not None
+
+    def test_extract_relations_false_pipeline_writes_no_relations(self, conn) -> None:
+        Model = build_extraction_model(
+            entity_type_slugs=["person", "task"],
+            relation_type_slugs=["assigned_to"],
+            registry_hash=registry_hash(conn),
+        )
+        scripted = Model(
+            title="t",
+            entities=[
+                {"type": "task", "name": "x",
+                 "fields": {"status": "pending", "priority": "medium"}},
+                {"type": "person", "name": "y"},
+            ],
+            relations=[
+                {"type": "assigned_to",
+                 "source": {"type": "task", "name": "x"},
+                 "target": {"type": "person", "name": "y"}},
+            ],
+        )
+        fake = FakeLLM(extract_responses=[scripted])
+        pipeline = IngestionPipeline(
+            store=DocumentStore(conn), llm=fake, extract_relations=False
+        )
+        report = pipeline.ingest_text("本文", source_path="memo/n.md")
+        assert report.relations_added == 0
+        assert conn.execute("SELECT COUNT(*) AS n FROM relations").fetchone()["n"] == 0
+
+    def test_validation_error_reports_extraction_warning(self, conn) -> None:
+        """An LLM-emitted entity with a bad enum value lands as a non-fatal note."""
+        Model = build_extraction_model(
+            entity_type_slugs=["person", "task"],
+            relation_type_slugs=["assigned_to"],
+            registry_hash=registry_hash(conn),
+        )
+        scripted = Model(
+            title="t",
+            entities=[
+                # Bad status → upsert_entity raises ValueError, pipeline records it.
+                {"type": "task", "name": "broken",
+                 "fields": {"status": "definitely_not_a_status", "priority": "medium"}},
+            ],
+        )
+        fake = FakeLLM(extract_responses=[scripted])
+        pipeline = IngestionPipeline(store=DocumentStore(conn), llm=fake)
+        report = pipeline.ingest_text("本文", source_path="memo/v.md")
+        assert report.status == "created"
+        assert report.entities_added_by_type == {}
+        assert report.extraction_error and "broken" in report.extraction_error

--- a/tests/docdb/test_llm.py
+++ b/tests/docdb/test_llm.py
@@ -17,6 +17,8 @@ import math
 
 import pytest
 
+from pydantic import BaseModel
+
 from docdb.llm import LLM, FakeLLM, LLMProtocol
 from docdb.llm.fake import StubChatCompletion
 from docdb.models import ExtractionResult
@@ -55,14 +57,30 @@ def test_extract_falls_back_to_default_instance_when_unscripted() -> None:
     assert result.tags == []
 
 
-def test_extract_type_mismatch_raises_clearly() -> None:
-    class _OtherSchema(ExtractionResult):
-        pass
+def test_extract_type_mismatch_raises_for_unrelated_schemas() -> None:
+    """Strictness still applies for schemas that share no inheritance."""
+
+    class _Unrelated(BaseModel):
+        foo: str = ""
 
     fake = FakeLLM(extract_responses=[ExtractionResult()])
 
     with pytest.raises(TypeError, match="scripted response"):
-        fake.extract("x", _OtherSchema)
+        fake.extract("x", _Unrelated)
+
+
+def test_extract_upcasts_parent_to_dynamic_subclass() -> None:
+    """Stage 3 dynamic models inherit from ExtractionResult; scripted parents
+    must be auto-upcast so existing tests do not have to know the dynamic
+    class name."""
+
+    class _Dynamic(ExtractionResult):
+        extra: list[str] = []  # default → not required from upcast payload
+
+    fake = FakeLLM(extract_responses=[ExtractionResult(title="upcast me")])
+    out = fake.extract("anything", _Dynamic)
+    assert isinstance(out, _Dynamic)
+    assert out.title == "upcast me"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
… (Stage 3)

The pipeline once again writes entities and relations. Both the system prompt and the Pydantic schema handed to ``instructor`` are now built per-call from the registered entity / relation types, so user-defined types extracted via the UI flow straight into ingest without code changes.

Backend:
- ``docdb.typing.dynamic_model.build_extraction_model`` constructs an ``ExtractionResult`` subclass per registry hash. ``entities[].type`` and ``relations[].type`` are Literal-constrained to the registered slugs so the LLM cannot invent new ones. Results are cached by registry hash.
- ``build_extraction_system_prompt`` renders every entity / relation type (slug, label, description, FieldSpec summary, extraction_hint). The assembled prompt is hard-capped at ``Settings.extraction_prompt_max_bytes`` (default 30 KB) — overflow drops trailing catalogue entries and emits a ``[... 型カタログを一部省略 ...]`` marker.
- ``Extractor`` accepts the registry at construction; ``IngestionPipeline`` reads it from the store conn and feeds the Extractor + normaliser the current set of slugs.
- Normaliser restores entity / relation building. Entities with unknown ``type`` slugs and relations whose ``source`` / ``target`` cannot be resolved within the same document are dropped and surface as ``NormalizationDrop`` records on the report.
- ``docdb.typing.deterministic.task_checkbox`` is the first pluggable per-type extractor: Markdown ``- [ ]`` items and ``TODO:`` lines become ``task`` entities with inferred priority. The pipeline merges its output into the LLM result before normalisation so dedup happens in one place.
- ``Settings.extract_relations`` lets users disable relation extraction when the small Ollama model hallucinates edges.
- ``FakeLLM.extract`` upcasts scripted parent-class instances to dynamic subclasses so existing tests do not need to know about the registry-hash schema name; intentionally-invalid payloads are preserved via ``model_construct`` for fallback-behaviour tests.

Tests: 23 new cases in ``test_dynamic_extraction.py`` covering dynamic model construction, prompt assembly (slug coverage + cap), normaliser drops, deterministic extractor invocation, and end-to-end pipeline writes with the registry. Full suite 287 passing.