### PR TITLE
feat(frontend): dynamic forms for entity & relation type editing (Sta…

### DIFF
--- a/src/frontend/src/api/client.ts
+++ b/src/frontend/src/api/client.ts
@@ -28,8 +28,13 @@ export const api = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body?: unknown) =>
     request<T>(path, { method: "POST", body: body ? JSON.stringify(body) : "{}" }),
+  put: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: "PUT", body: body ? JSON.stringify(body) : "{}" }),
   patch: <T>(path: string, body?: unknown) =>
     request<T>(path, { method: "PATCH", body: body ? JSON.stringify(body) : "{}" }),
+  // Named ``deleteRoute`` because ``delete`` is a reserved word.
+  deleteRoute: <T = void>(path: string) =>
+    request<T>(path, { method: "DELETE" }),
 };
 
 export const fetcher = <T>(path: string) => api.get<T>(path);

--- a/src/frontend/src/api/useTypes.ts
+++ b/src/frontend/src/api/useTypes.ts
@@ -1,0 +1,56 @@
+import useSWR, { mutate } from "swr";
+import { useMemo } from "react";
+import { fetcher } from "./client";
+import type { EntityTypeDef, RelationTypeDef } from "./types";
+
+const ENTITY_TYPES_KEY = "/api/types/entities";
+const RELATION_TYPES_KEY = "/api/types/relations";
+
+/**
+ * Shared SWR cache over the runtime type registry.
+ *
+ * Components that render dynamic forms or schema-driven columns subscribe to
+ * this hook so the prompt-to-paint path is single-fetch and the cache survives
+ * navigations. After a Settings edit, call ``refresh()`` to broadcast a
+ * revalidation to every subscriber.
+ */
+export function useTypes() {
+  const entities = useSWR<EntityTypeDef[]>(ENTITY_TYPES_KEY, fetcher, {
+    revalidateOnFocus: false,
+    dedupingInterval: 60_000,
+  });
+  const relations = useSWR<RelationTypeDef[]>(RELATION_TYPES_KEY, fetcher, {
+    revalidateOnFocus: false,
+    dedupingInterval: 60_000,
+  });
+
+  const entityBySlug = useMemo(() => {
+    const m = new Map<string, EntityTypeDef>();
+    for (const t of entities.data ?? []) m.set(t.slug, t);
+    return m;
+  }, [entities.data]);
+
+  const relationBySlug = useMemo(() => {
+    const m = new Map<string, RelationTypeDef>();
+    for (const t of relations.data ?? []) m.set(t.slug, t);
+    return m;
+  }, [relations.data]);
+
+  return {
+    entityTypes: entities.data,
+    relationTypes: relations.data,
+    entityBySlug,
+    relationBySlug,
+    isLoading: entities.isLoading || relations.isLoading,
+    error: entities.error || relations.error,
+    refresh: () => {
+      mutate(ENTITY_TYPES_KEY);
+      mutate(RELATION_TYPES_KEY);
+    },
+  };
+}
+
+export function refreshTypes() {
+  mutate(ENTITY_TYPES_KEY);
+  mutate(RELATION_TYPES_KEY);
+}

--- a/src/frontend/src/components/DynamicForm.module.css
+++ b/src/frontend/src/components/DynamicForm.module.css
@@ -1,0 +1,92 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.label {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.required {
+  color: var(--color-danger, #c93030);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.fieldName {
+  font-family: var(--font-mono, monospace);
+  font-weight: 400;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+.input,
+.textarea,
+.select {
+  padding: var(--space-2) var(--space-3);
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+
+.textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+.error {
+  color: var(--color-danger, #c93030);
+  font-size: 0.8rem;
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.primary {
+  padding: 8px 14px;
+  background-color: var(--color-accent);
+  color: var(--color-background, #fff);
+  border: 0;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.secondary {
+  padding: 8px 14px;
+  background-color: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}

--- a/src/frontend/src/components/DynamicForm.tsx
+++ b/src/frontend/src/components/DynamicForm.tsx
@@ -1,0 +1,384 @@
+import { useState } from "react";
+import useSWR from "swr";
+import { fetcher } from "../api/client";
+import type { EntityRef, FieldSpec, FieldSpecType } from "../api/types";
+import styles from "./DynamicForm.module.css";
+
+export type DynamicFormValues = Record<string, unknown>;
+
+interface DynamicFormProps {
+  fields: FieldSpec[];
+  /** Optional preloaded values keyed by field name. */
+  initial?: DynamicFormValues;
+  /** Built-in inputs for entity-level metadata. The form renders these as a
+   * header section so the dynamic fields below stay focused on the type
+   * schema. Optional — Settings doesn't need them. */
+  headerFields?: HeaderFieldSpec[];
+  submitLabel?: string;
+  onSubmit: (values: DynamicFormValues) => void | Promise<void>;
+  onCancel?: () => void;
+  submitting?: boolean;
+}
+
+export interface HeaderFieldSpec {
+  name: string;
+  label: string;
+  type: "string" | "text";
+  required?: boolean;
+  placeholder?: string;
+}
+
+const TEXT_WIDGET_TYPES = new Set<FieldSpecType>(["text"]);
+
+export default function DynamicForm({
+  fields,
+  initial,
+  headerFields,
+  submitLabel = "Save",
+  onSubmit,
+  onCancel,
+  submitting = false,
+}: DynamicFormProps) {
+  const [values, setValues] = useState<DynamicFormValues>(() =>
+    seedValues(fields, initial ?? {}, headerFields),
+  );
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  function setField(name: string, value: unknown) {
+    setValues((prev) => ({ ...prev, [name]: value }));
+    if (errors[name]) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next[name];
+        return next;
+      });
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const v = { ...values };
+    const errs: Record<string, string> = {};
+
+    for (const h of headerFields ?? []) {
+      const value = (v[h.name] ?? "") as string;
+      if (h.required && !value.trim()) {
+        errs[h.name] = "必須項目です";
+      }
+    }
+    for (const f of fields) {
+      if (f.required && isEmpty(v[f.name])) {
+        errs[f.name] = "必須項目です";
+      }
+    }
+    if (Object.keys(errs).length > 0) {
+      setErrors(errs);
+      return;
+    }
+
+    await onSubmit(v);
+  }
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      {(headerFields ?? []).map((h) => (
+        <HeaderField
+          key={h.name}
+          spec={h}
+          value={(values[h.name] as string) ?? ""}
+          error={errors[h.name]}
+          onChange={(v) => setField(h.name, v)}
+        />
+      ))}
+
+      {fields.map((f) => (
+        <DynamicField
+          key={f.name}
+          spec={f}
+          value={values[f.name]}
+          error={errors[f.name]}
+          onChange={(v) => setField(f.name, v)}
+        />
+      ))}
+
+      <div className={styles.actions}>
+        <button
+          type="submit"
+          className={styles.primary}
+          disabled={submitting}
+        >
+          {submitting ? "..." : submitLabel}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            className={styles.secondary}
+            onClick={onCancel}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-field widgets
+// ---------------------------------------------------------------------------
+function HeaderField({
+  spec,
+  value,
+  error,
+  onChange,
+}: {
+  spec: HeaderFieldSpec;
+  value: string;
+  error?: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className={styles.field}>
+      <span className={styles.label}>
+        {spec.label}
+        <span className={styles.fieldName}>{spec.name}</span>
+        {spec.required && <span className={styles.required}>required</span>}
+      </span>
+      {spec.type === "text" ? (
+        <textarea
+          className={styles.textarea}
+          value={value}
+          placeholder={spec.placeholder}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      ) : (
+        <input
+          className={styles.input}
+          value={value}
+          placeholder={spec.placeholder}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      )}
+      {error && <span className={styles.error}>{error}</span>}
+    </label>
+  );
+}
+
+function DynamicField({
+  spec,
+  value,
+  error,
+  onChange,
+}: {
+  spec: FieldSpec;
+  value: unknown;
+  error?: string;
+  onChange: (v: unknown) => void;
+}) {
+  return (
+    <label className={styles.field}>
+      <span className={styles.label}>
+        {spec.label}
+        <span className={styles.fieldName}>{spec.name}</span>
+        {spec.required && <span className={styles.required}>required</span>}
+      </span>
+      <Widget spec={spec} value={value} onChange={onChange} />
+      {error && <span className={styles.error}>{error}</span>}
+    </label>
+  );
+}
+
+function Widget({
+  spec,
+  value,
+  onChange,
+}: {
+  spec: FieldSpec;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  if (spec.type === "enum") {
+    return (
+      <select
+        className={styles.select}
+        value={(value as string) ?? ""}
+        onChange={(e) => onChange(e.target.value || null)}
+      >
+        {!spec.required && <option value="">（未設定）</option>}
+        {(spec.options ?? []).map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    );
+  }
+  if (spec.type === "bool") {
+    return (
+      <span className={styles.checkbox}>
+        <input
+          type="checkbox"
+          checked={Boolean(value)}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <span>{spec.label}</span>
+      </span>
+    );
+  }
+  if (TEXT_WIDGET_TYPES.has(spec.type) || spec.ui_widget === "textarea") {
+    return (
+      <textarea
+        className={styles.textarea}
+        value={(value as string) ?? ""}
+        onChange={(e) => onChange(e.target.value || null)}
+      />
+    );
+  }
+  if (spec.type === "ref") {
+    return (
+      <RefWidget spec={spec} value={value as string | null} onChange={onChange} />
+    );
+  }
+
+  const inputType = inputTypeFor(spec.type);
+  return (
+    <input
+      className={styles.input}
+      type={inputType}
+      value={
+        value === null || value === undefined
+          ? ""
+          : typeof value === "boolean"
+            ? String(value)
+            : (value as string | number).toString()
+      }
+      step={spec.type === "float" ? "any" : undefined}
+      onChange={(e) => onChange(parseInputValue(spec.type, e.target.value))}
+    />
+  );
+}
+
+function RefWidget({
+  spec,
+  value,
+  onChange,
+}: {
+  spec: FieldSpec;
+  value: string | null;
+  onChange: (v: string | null) => void;
+}) {
+  // Stage 4 keeps refs simple: a select populated from `/api/entities?type_slug=...`.
+  // Stage 5+ could swap in a typeahead.
+  const url = spec.ref_type_slug
+    ? `/api/entities?type_slug=${encodeURIComponent(spec.ref_type_slug)}&top_k=200`
+    : null;
+  const { data } = useSWR<EntityRef[]>(url, fetcher);
+
+  return (
+    <select
+      className={styles.select}
+      value={value ?? ""}
+      onChange={(e) => onChange(e.target.value || null)}
+    >
+      <option value="">（未設定）</option>
+      {(data ?? []).map((e) => (
+        <option key={e.id} value={e.id}>
+          {e.canonical_name}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function seedValues(
+  fields: FieldSpec[],
+  initial: DynamicFormValues,
+  headerFields?: HeaderFieldSpec[],
+): DynamicFormValues {
+  const seeded: DynamicFormValues = { ...initial };
+  for (const h of headerFields ?? []) {
+    if (seeded[h.name] === undefined) {
+      seeded[h.name] = "";
+    }
+  }
+  for (const f of fields) {
+    if (seeded[f.name] !== undefined) continue;
+    if (f.default !== undefined && f.default !== null) {
+      seeded[f.name] = f.default;
+    } else if (f.type === "bool") {
+      seeded[f.name] = false;
+    } else {
+      seeded[f.name] = null;
+    }
+  }
+  return seeded;
+}
+
+function inputTypeFor(t: FieldSpecType): string {
+  switch (t) {
+    case "int":
+    case "float":
+      return "number";
+    case "date":
+      return "date";
+    case "datetime":
+      return "datetime-local";
+    case "url":
+      return "url";
+    default:
+      return "text";
+  }
+}
+
+function parseInputValue(t: FieldSpecType, raw: string): unknown {
+  if (raw === "") return null;
+  if (t === "int") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? Math.trunc(n) : raw;
+  }
+  if (t === "float") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : raw;
+  }
+  if (t === "datetime") {
+    // datetime-local emits "YYYY-MM-DDTHH:MM" — append seconds + Z when missing
+    // so the backend's ISO parser accepts it.
+    if (raw.length === 16) return `${raw}:00Z`;
+    return raw;
+  }
+  return raw;
+}
+
+function isEmpty(v: unknown): boolean {
+  if (v === null || v === undefined) return true;
+  if (typeof v === "string" && v.trim() === "") return true;
+  return false;
+}
+
+/**
+ * Pack a DynamicForm submission into the shape ``/api/entities`` POST expects.
+ * Caller splits header fields (canonical_name, description) from dynamic fields.
+ */
+export function pickFieldValues(
+  values: DynamicFormValues,
+  fields: FieldSpec[],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const f of fields) {
+    const v = values[f.name];
+    if (v === undefined || v === null) {
+      if (f.required) {
+        // Required value left blank — pass through; the server will surface a
+        // 400 with a useful message. We do not silently drop required nulls.
+        out[f.name] = v ?? "";
+      }
+      continue;
+    }
+    out[f.name] = v;
+  }
+  return out;
+}

--- a/src/frontend/src/components/FieldSpecEditor.module.css
+++ b/src/frontend/src/components/FieldSpecEditor.module.css
@@ -1,0 +1,91 @@
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 120px 90px 90px;
+  gap: var(--space-2);
+  align-items: end;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-surface);
+}
+
+.full {
+  grid-column: 1 / -1;
+}
+
+.label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  margin-bottom: 2px;
+}
+
+.input,
+.select {
+  width: 100%;
+  padding: 6px 10px;
+  background-color: var(--color-surface-alt, var(--color-surface));
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 4px);
+  font-size: 0.85rem;
+  font-family: inherit;
+}
+
+.smallCheckbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--color-text);
+}
+
+.remove {
+  padding: 4px 8px;
+  background-color: transparent;
+  color: var(--color-danger, #c93030);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 4px);
+  cursor: pointer;
+  font-size: 0.8rem;
+  height: 32px;
+  align-self: end;
+}
+
+.move {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.moveBtn {
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  background: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 4px);
+  cursor: pointer;
+}
+
+.add {
+  align-self: flex-start;
+  padding: 6px 12px;
+  background-color: transparent;
+  color: var(--color-accent);
+  border: 1px dashed var(--color-accent);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 0.85rem;
+}

--- a/src/frontend/src/components/FieldSpecEditor.tsx
+++ b/src/frontend/src/components/FieldSpecEditor.tsx
@@ -1,0 +1,226 @@
+import type { FieldSpec, FieldSpecType } from "../api/types";
+import styles from "./FieldSpecEditor.module.css";
+
+const FIELD_TYPES: FieldSpecType[] = [
+  "string",
+  "text",
+  "int",
+  "float",
+  "bool",
+  "date",
+  "datetime",
+  "enum",
+  "url",
+  "ref",
+];
+
+interface FieldSpecEditorProps {
+  value: FieldSpec[];
+  onChange: (next: FieldSpec[]) => void;
+  /** Slugs eligible to be referenced by ``ref`` fields (populated from the
+   * entity type registry by the parent). */
+  refTypeSlugs?: string[];
+}
+
+export default function FieldSpecEditor({
+  value,
+  onChange,
+  refTypeSlugs,
+}: FieldSpecEditorProps) {
+  function update(i: number, patch: Partial<FieldSpec>) {
+    const next = [...value];
+    next[i] = { ...next[i], ...patch };
+    onChange(next);
+  }
+  function remove(i: number) {
+    onChange(value.filter((_, idx) => idx !== i));
+  }
+  function move(i: number, delta: number) {
+    const j = i + delta;
+    if (j < 0 || j >= value.length) return;
+    const next = [...value];
+    [next[i], next[j]] = [next[j], next[i]];
+    onChange(next);
+  }
+  function add() {
+    const i = value.length + 1;
+    onChange([
+      ...value,
+      {
+        name: `field_${i}`,
+        label: `Field ${i}`,
+        type: "string",
+        required: false,
+      },
+    ]);
+  }
+
+  return (
+    <div className={styles.editor}>
+      <div className={styles.rows}>
+        {value.map((spec, i) => (
+          <FieldRow
+            key={i}
+            spec={spec}
+            refTypeSlugs={refTypeSlugs ?? []}
+            onChange={(patch) => update(i, patch)}
+            onRemove={() => remove(i)}
+            onMoveUp={i > 0 ? () => move(i, -1) : undefined}
+            onMoveDown={i < value.length - 1 ? () => move(i, +1) : undefined}
+          />
+        ))}
+      </div>
+      <button type="button" className={styles.add} onClick={add}>
+        + Add field
+      </button>
+    </div>
+  );
+}
+
+interface FieldRowProps {
+  spec: FieldSpec;
+  refTypeSlugs: string[];
+  onChange: (patch: Partial<FieldSpec>) => void;
+  onRemove: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+}
+
+function FieldRow({
+  spec,
+  refTypeSlugs,
+  onChange,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+}: FieldRowProps) {
+  return (
+    <div className={styles.row}>
+      <label>
+        <div className={styles.label}>name</div>
+        <input
+          className={styles.input}
+          value={spec.name}
+          onChange={(e) => onChange({ name: e.target.value })}
+          placeholder="snake_case"
+        />
+      </label>
+      <label>
+        <div className={styles.label}>label</div>
+        <input
+          className={styles.input}
+          value={spec.label}
+          onChange={(e) => onChange({ label: e.target.value })}
+        />
+      </label>
+      <label>
+        <div className={styles.label}>type</div>
+        <select
+          className={styles.select}
+          value={spec.type}
+          onChange={(e) =>
+            onChange({
+              type: e.target.value as FieldSpecType,
+              // Clear type-specific extras so the saved schema stays clean.
+              options: e.target.value === "enum" ? (spec.options ?? []) : undefined,
+              ref_type_slug:
+                e.target.value === "ref" ? spec.ref_type_slug : undefined,
+            })
+          }
+        >
+          {FIELD_TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className={styles.smallCheckbox}>
+        <input
+          type="checkbox"
+          checked={Boolean(spec.required)}
+          onChange={(e) => onChange({ required: e.target.checked })}
+        />
+        required
+      </label>
+      <div className={styles.move}>
+        <button
+          type="button"
+          className={styles.moveBtn}
+          onClick={onMoveUp}
+          disabled={!onMoveUp}
+        >
+          ↑
+        </button>
+        <button
+          type="button"
+          className={styles.moveBtn}
+          onClick={onMoveDown}
+          disabled={!onMoveDown}
+        >
+          ↓
+        </button>
+        <button
+          type="button"
+          className={styles.remove}
+          onClick={onRemove}
+          title="Remove field"
+        >
+          ✕
+        </button>
+      </div>
+
+      {spec.type === "enum" && (
+        <label className={styles.full}>
+          <div className={styles.label}>options (one per line)</div>
+          <textarea
+            className={styles.input}
+            value={(spec.options ?? []).join("\n")}
+            rows={3}
+            onChange={(e) =>
+              onChange({
+                options: e.target.value
+                  .split(/\r?\n/)
+                  .map((s) => s.trim())
+                  .filter(Boolean),
+              })
+            }
+          />
+        </label>
+      )}
+
+      {spec.type === "ref" && (
+        <label className={styles.full}>
+          <div className={styles.label}>ref_type_slug</div>
+          <select
+            className={styles.select}
+            value={spec.ref_type_slug ?? ""}
+            onChange={(e) =>
+              onChange({ ref_type_slug: e.target.value || undefined })
+            }
+          >
+            <option value="">(any entity)</option>
+            {refTypeSlugs.map((slug) => (
+              <option key={slug} value={slug}>
+                {slug}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      {(spec.type === "enum" || spec.type === "string") && (
+        <label className={styles.full}>
+          <div className={styles.label}>default (optional)</div>
+          <input
+            className={styles.input}
+            value={(spec.default as string | undefined) ?? ""}
+            onChange={(e) =>
+              onChange({ default: e.target.value || undefined })
+            }
+          />
+        </label>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/routes/Entities.module.css
+++ b/src/frontend/src/routes/Entities.module.css
@@ -1,7 +1,8 @@
 .filters {
   display: flex;
   gap: var(--space-2);
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-3);
+  align-items: center;
 }
 
 .search {
@@ -21,9 +22,50 @@
   border-radius: var(--radius-md);
 }
 
+.newBtn {
+  padding: 8px 14px;
+  background-color: var(--color-accent);
+  color: var(--color-background, #fff);
+  border: 0;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.typeChips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: var(--space-3);
+}
+
+.chip {
+  padding: 4px 10px;
+  background-color: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.chipActive {
+  background-color: var(--color-accent);
+  color: var(--color-background, #fff);
+  border-color: var(--color-accent);
+}
+
+.editorPanel {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
 .layout {
   display: grid;
-  grid-template-columns: 280px 1fr;
+  grid-template-columns: 320px 1fr;
   gap: var(--space-4);
 }
 
@@ -31,21 +73,18 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-  max-height: 70vh;
+  max-height: 75vh;
   overflow-y: auto;
 }
 
 .item {
   text-align: left;
   background-color: var(--color-surface);
+  color: var(--color-text);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  padding: var(--space-3);
-  color: var(--color-text);
-}
-
-.item:hover {
-  background-color: var(--color-surface-2);
+  padding: 10px 12px;
+  cursor: pointer;
 }
 
 .itemActive {
@@ -55,8 +94,9 @@
 .itemHead {
   display: flex;
   justify-content: space-between;
+  gap: 8px;
+  font-size: 0.9rem;
   align-items: center;
-  gap: var(--space-2);
 }
 
 .itemName {
@@ -64,57 +104,98 @@
 }
 
 .itemMeta {
-  margin-top: var(--space-1);
-  font-size: 11px;
-  color: var(--color-muted);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin-top: 4px;
 }
 
 .detail {
   background-color: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  padding: var(--space-5);
+  padding: var(--space-3);
 }
 
 .detailTitle {
-  margin: 0 0 var(--space-3);
-  font-size: 18px;
   display: flex;
   align-items: center;
+  gap: 8px;
+  margin: 0 0 var(--space-2);
+}
+
+.detailActions {
+  display: flex;
   gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.detailActions button {
+  padding: 4px 10px;
+  font-size: 0.85rem;
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 4px);
+  cursor: pointer;
 }
 
 .aliases {
-  color: var(--color-muted);
-  font-size: 12px;
-  margin-bottom: var(--space-4);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2);
+}
+
+.fields {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px var(--space-2);
+  font-size: 0.9rem;
+  margin-bottom: var(--space-2);
+}
+
+.fieldKey {
+  font-family: var(--font-mono, monospace);
+  color: var(--color-text-muted);
 }
 
 .docsHeader {
-  margin: 0 0 var(--space-2);
-  font-size: 11px;
-  color: var(--color-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+  font-size: 1rem;
+  margin: var(--space-3) 0 var(--space-2);
 }
 
 .docs {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   list-style: none;
   padding: 0;
   margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
 }
 
 .docs li {
   display: flex;
-  justify-content: space-between;
-  padding: var(--space-2) 0;
-  border-bottom: 1px solid var(--color-border);
+  gap: 8px;
+  align-items: baseline;
 }
 
 .muted {
-  color: var(--color-muted);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.error {
+  color: var(--color-danger, #c93030);
+  font-size: 0.85rem;
+  margin-top: var(--space-2);
+}
+
+.relations {
+  margin-top: var(--space-3);
+}
+
+.relRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 0.85rem;
 }

--- a/src/frontend/src/routes/Entities.tsx
+++ b/src/frontend/src/routes/Entities.tsx
@@ -1,55 +1,143 @@
 import { useEffect, useState } from "react";
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 import { Link, useSearchParams } from "react-router-dom";
-import { fetcher } from "../api/client";
+import { ApiError, api, fetcher } from "../api/client";
+import { useTypes } from "../api/useTypes";
 import type {
   DocumentDetail,
   EntityRef,
   EntityTypeDef,
+  FieldSpec,
+  RelationRef,
 } from "../api/types";
 import PageHeader from "../components/PageHeader";
 import EmptyState from "../components/EmptyState";
 import Badge from "../components/Badge";
+import DynamicForm, {
+  DynamicFormValues,
+  pickFieldValues,
+  HeaderFieldSpec,
+} from "../components/DynamicForm";
 import styles from "./Entities.module.css";
+
+type Mode =
+  | { kind: "idle" }
+  | { kind: "create"; typeSlug: string }
+  | { kind: "edit"; entityId: string };
+
+const HEADER_FIELDS: HeaderFieldSpec[] = [
+  {
+    name: "canonical_name",
+    label: "canonical name",
+    type: "string",
+    required: true,
+    placeholder: "正規名 (一意のラベル)",
+  },
+  {
+    name: "description",
+    label: "description",
+    type: "text",
+    placeholder: "任意のメモ",
+  },
+  {
+    name: "aliases",
+    label: "aliases (カンマ区切り)",
+    type: "string",
+    placeholder: "Alice, A. Tanaka",
+  },
+];
 
 export default function Entities() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [q, setQ] = useState("");
-  const [typeSlug, setTypeSlug] = useState<string>(searchParams.get("type") || "");
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const initialType = searchParams.get("type") ?? "";
 
-  // Sync the type filter back to the URL so /entities?type=task is shareable.
+  const [q, setQ] = useState("");
+  const [typeSlug, setTypeSlug] = useState<string>(initialType);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>({ kind: "idle" });
+
+  const { entityTypes, entityBySlug } = useTypes();
+
+  // Keep ?type= in the URL synced.
   useEffect(() => {
+    const next = new URLSearchParams(searchParams);
     if (typeSlug) {
-      setSearchParams({ type: typeSlug }, { replace: true });
-    } else if (searchParams.has("type")) {
-      setSearchParams({}, { replace: true });
+      next.set("type", typeSlug);
+    } else {
+      next.delete("type");
     }
+    setSearchParams(next, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [typeSlug]);
 
-  const { data: types } = useSWR<EntityTypeDef[]>("/api/types/entities", fetcher);
+  // Default the selected type once the registry loads.
+  useEffect(() => {
+    if (!typeSlug && entityTypes && entityTypes.length > 0) {
+      setTypeSlug(entityTypes[0].slug);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entityTypes]);
 
   const params = new URLSearchParams();
   params.set("top_k", "100");
   if (q.trim()) params.set("q", q.trim());
   if (typeSlug) params.set("type_slug", typeSlug);
-
-  const { data: entities } = useSWR<EntityRef[]>(
-    `/api/entities?${params.toString()}`,
+  const listUrl = `/api/entities?${params.toString()}`;
+  const { data: entities, mutate: mutateEntities } = useSWR<EntityRef[]>(
+    listUrl,
     fetcher,
   );
 
-  const { data: docs } = useSWR<DocumentDetail[]>(
-    selectedId ? `/api/entities/${selectedId}/documents` : null,
-    fetcher,
-  );
+  const selectedType: EntityTypeDef | undefined = typeSlug
+    ? entityBySlug.get(typeSlug)
+    : undefined;
+  const fieldsSchema: FieldSpec[] = selectedType?.fields_schema ?? [];
 
   const selected = entities?.find((e) => e.id === selectedId) ?? null;
 
+  function reloadAll() {
+    mutateEntities();
+    // Stats card on the dashboard relies on the same data.
+    mutate("/api/stats");
+  }
+
   return (
     <div>
-      <PageHeader title="Entities" subtitle={`${entities?.length ?? 0} 件`} />
+      <PageHeader
+        title="Entities"
+        subtitle={`${entities?.length ?? 0} 件`}
+      />
+
+      <div className={styles.typeChips}>
+        <button
+          className={!typeSlug ? `${styles.chip} ${styles.chipActive}` : styles.chip}
+          onClick={() => {
+            setTypeSlug("");
+            setSelectedId(null);
+            setMode({ kind: "idle" });
+          }}
+        >
+          All types
+        </button>
+        {entityTypes?.map((t) => (
+          <button
+            key={t.slug}
+            className={
+              t.slug === typeSlug
+                ? `${styles.chip} ${styles.chipActive}`
+                : styles.chip
+            }
+            onClick={() => {
+              setTypeSlug(t.slug);
+              setSelectedId(null);
+              setMode({ kind: "idle" });
+            }}
+          >
+            {t.label}{" "}
+            <span style={{ opacity: 0.7 }}>({t.slug})</span>
+          </button>
+        ))}
+      </div>
 
       <div className={styles.filters}>
         <input
@@ -59,19 +147,57 @@ export default function Entities() {
           value={q}
           onChange={(e) => setQ(e.target.value)}
         />
-        <select
-          className={styles.select}
-          value={typeSlug}
-          onChange={(e) => setTypeSlug(e.target.value)}
-        >
-          <option value="">All types</option>
-          {types?.map((t) => (
-            <option key={t.slug} value={t.slug}>
-              {t.label} ({t.slug})
-            </option>
-          ))}
-        </select>
+        {typeSlug && (
+          <button
+            className={styles.newBtn}
+            onClick={() => setMode({ kind: "create", typeSlug })}
+          >
+            + New {selectedType?.label ?? typeSlug}
+          </button>
+        )}
       </div>
+
+      {mode.kind === "create" && (
+        <div className={styles.editorPanel}>
+          <h3>New {selectedType?.label}</h3>
+          <EntityForm
+            fields={fieldsSchema}
+            onSubmit={async (values) => {
+              await api.post("/api/entities", buildEntityPayload(values, fieldsSchema, mode.typeSlug));
+              setMode({ kind: "idle" });
+              reloadAll();
+            }}
+            onCancel={() => setMode({ kind: "idle" })}
+          />
+        </div>
+      )}
+
+      {mode.kind === "edit" && selected && (
+        <div className={styles.editorPanel}>
+          <h3>Edit {selected.canonical_name}</h3>
+          <EntityForm
+            fields={fieldsSchema}
+            initial={{
+              canonical_name: selected.canonical_name,
+              description: selected.description ?? "",
+              aliases: (selected.aliases || []).join(", "),
+              ...(selected.fields ?? {}),
+            }}
+            onSubmit={async (values) => {
+              const payload: Record<string, unknown> = {
+                canonical_name: values.canonical_name,
+                description: values.description || null,
+                aliases: parseAliases(values.aliases as string),
+                fields: pickFieldValues(values, fieldsSchema),
+              };
+              await api.patch(`/api/entities/${selected.id}`, payload);
+              setMode({ kind: "idle" });
+              reloadAll();
+            }}
+            onCancel={() => setMode({ kind: "idle" })}
+          />
+        </div>
+      )}
 
       <div className={styles.layout}>
         <div className={styles.list}>
@@ -82,65 +208,263 @@ export default function Entities() {
               className={`${styles.item} ${
                 e.id === selectedId ? styles.itemActive : ""
               }`}
-              onClick={() => setSelectedId(e.id)}
+              onClick={() => {
+                setSelectedId(e.id);
+                setMode({ kind: "idle" });
+              }}
             >
               <div className={styles.itemHead}>
                 <span className={styles.itemName}>{e.canonical_name}</span>
                 <Badge tone="muted">{e.type_slug}</Badge>
               </div>
-              {!!e.mention_total && (
-                <div className={styles.itemMeta}>
-                  {e.mention_total} mentions
-                </div>
-              )}
+              <ItemSummary entity={e} type={entityBySlug.get(e.type_slug)} />
             </button>
           ))}
         </div>
 
-        <div className={styles.detail}>
-          {!selected ? (
-            <EmptyState title="エンティティを選択" />
-          ) : (
-            <>
-              <h2 className={styles.detailTitle}>
-                {selected.canonical_name}{" "}
-                <Badge tone="muted">{selected.type_slug}</Badge>
-              </h2>
-              {selected.aliases.length > 0 && (
-                <div className={styles.aliases}>
-                  aliases: {selected.aliases.join(", ")}
-                </div>
-              )}
-              {selected.fields && Object.keys(selected.fields).length > 0 && (
-                <dl className={styles.aliases}>
-                  {Object.entries(selected.fields).map(([k, v]) => (
-                    <div key={k}>
-                      <strong>{k}:</strong> {String(v ?? "")}
-                    </div>
-                  ))}
-                </dl>
-              )}
-              <h3 className={styles.docsHeader}>Mentioned in</h3>
-              {!docs ? (
-                <div className={styles.muted}>Loading…</div>
-              ) : docs.length === 0 ? (
-                <EmptyState title="(no documents)" />
-              ) : (
-                <ul className={styles.docs}>
-                  {docs.map((d) => (
-                    <li key={d.id}>
-                      <Link to={`/documents/${d.id}`}>
-                        {d.title || d.source_path || d.id}
-                      </Link>
-                      <span className={styles.muted}>{d.doc_type || "—"}</span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </>
-          )}
-        </div>
+        <EntityDetail
+          entity={selected}
+          type={selected ? entityBySlug.get(selected.type_slug) : undefined}
+          onEdit={() => selected && setMode({ kind: "edit", entityId: selected.id })}
+          onDelete={async () => {
+            if (!selected) return;
+            if (!confirm(`"${selected.canonical_name}" を削除しますか？`)) return;
+            try {
+              await api.deleteRoute(`/api/entities/${selected.id}`);
+              setSelectedId(null);
+              reloadAll();
+            } catch (err) {
+              alert(err instanceof ApiError ? err.message : String(err));
+            }
+          }}
+        />
       </div>
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Detail panel
+// ---------------------------------------------------------------------------
+function EntityDetail({
+  entity,
+  type,
+  onEdit,
+  onDelete,
+}: {
+  entity: EntityRef | null;
+  type: EntityTypeDef | undefined;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const { data: docs } = useSWR<DocumentDetail[]>(
+    entity ? `/api/entities/${entity.id}/documents` : null,
+    fetcher,
+  );
+  const { data: outgoing } = useSWR<RelationRef[]>(
+    entity ? `/api/relations?source_entity_id=${entity.id}` : null,
+    fetcher,
+  );
+  const { data: incoming } = useSWR<RelationRef[]>(
+    entity ? `/api/relations?target_entity_id=${entity.id}` : null,
+    fetcher,
+  );
+
+  if (!entity) {
+    return (
+      <div className={styles.detail}>
+        <EmptyState title="エンティティを選択" />
+      </div>
+    );
+  }
+  return (
+    <div className={styles.detail}>
+      <h2 className={styles.detailTitle}>
+        {entity.canonical_name}{" "}
+        <Badge tone="muted">{entity.type_slug}</Badge>
+      </h2>
+      <div className={styles.detailActions}>
+        <button onClick={onEdit}>Edit</button>
+        <button onClick={onDelete}>Delete</button>
+      </div>
+      {entity.aliases.length > 0 && (
+        <div className={styles.aliases}>
+          aliases: {entity.aliases.join(", ")}
+        </div>
+      )}
+      {entity.description && (
+        <div className={styles.aliases}>{entity.description}</div>
+      )}
+      {entity.fields && Object.keys(entity.fields).length > 0 && (
+        <dl className={styles.fields}>
+          {(type?.fields_schema ?? []).map((spec) => {
+            const v = entity.fields?.[spec.name];
+            if (v === undefined || v === null || v === "") return null;
+            return (
+              <FieldRow key={spec.name} label={spec.label} name={spec.name} value={v} />
+            );
+          })}
+          {/* extras not declared in the schema (Stage 5 user types may drift) */}
+          {Object.entries(entity.fields)
+            .filter(([k]) => !(type?.fields_schema ?? []).some((s) => s.name === k))
+            .map(([k, v]) => (
+              <FieldRow key={k} label={k} name={k} value={v} />
+            ))}
+        </dl>
+      )}
+
+      <h3 className={styles.docsHeader}>Mentioned in</h3>
+      {!docs ? (
+        <div className={styles.muted}>Loading…</div>
+      ) : docs.length === 0 ? (
+        <EmptyState title="(no documents)" />
+      ) : (
+        <ul className={styles.docs}>
+          {docs.map((d) => (
+            <li key={d.id}>
+              <Link to={`/documents/${d.id}`}>
+                {d.title || d.source_path || d.id}
+              </Link>
+              <span className={styles.muted}>{d.doc_type || "—"}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(outgoing?.length || incoming?.length) ? (
+        <div className={styles.relations}>
+          <h3 className={styles.docsHeader}>Relations</h3>
+          {outgoing?.map((r) => (
+            <div key={r.id} className={styles.relRow}>
+              <Badge tone="accent">{r.type_slug}</Badge>
+              <span>→ {r.target_entity_id}</span>
+            </div>
+          ))}
+          {incoming?.map((r) => (
+            <div key={r.id} className={styles.relRow}>
+              <span>{r.source_entity_id} →</span>
+              <Badge tone="accent">{r.type_slug}</Badge>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FieldRow({
+  label,
+  name,
+  value,
+}: {
+  label: string;
+  name: string;
+  value: unknown;
+}) {
+  return (
+    <>
+      <div className={styles.fieldKey} title={name}>
+        {label}
+      </div>
+      <div>{formatValue(value)}</div>
+    </>
+  );
+}
+
+function formatValue(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
+
+// ---------------------------------------------------------------------------
+// EntityForm wraps DynamicForm with the canonical_name / description / aliases
+// header so the dynamic fields stay focused on the FieldSpec[] view.
+// ---------------------------------------------------------------------------
+function EntityForm({
+  fields,
+  initial,
+  onSubmit,
+  onCancel,
+}: {
+  fields: FieldSpec[];
+  initial?: DynamicFormValues;
+  onSubmit: (values: DynamicFormValues) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  return (
+    <>
+      <DynamicForm
+        fields={fields}
+        headerFields={HEADER_FIELDS}
+        initial={initial}
+        submitting={submitting}
+        onCancel={onCancel}
+        submitLabel="Save"
+        onSubmit={async (values) => {
+          setError(null);
+          setSubmitting(true);
+          try {
+            await onSubmit(values);
+          } catch (err) {
+            setError(err instanceof ApiError ? err.message : String(err));
+          } finally {
+            setSubmitting(false);
+          }
+        }}
+      />
+      {error && <div className={styles.error}>{error}</div>}
+    </>
+  );
+}
+
+function ItemSummary({
+  entity,
+  type,
+}: {
+  entity: EntityRef;
+  type?: EntityTypeDef;
+}) {
+  if (!type || type.fields_schema.length === 0) {
+    if (entity.mention_total) {
+      return (
+        <div className={styles.itemMeta}>{entity.mention_total} mentions</div>
+      );
+    }
+    return null;
+  }
+  // Show first 2 field values for a quick scan in the list.
+  const pairs = type.fields_schema
+    .slice(0, 2)
+    .map((f) => entity.fields?.[f.name])
+    .filter((v) => v !== null && v !== undefined && v !== "");
+  if (pairs.length === 0) return null;
+  return <div className={styles.itemMeta}>{pairs.join(" · ")}</div>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function parseAliases(raw: string): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function buildEntityPayload(
+  values: DynamicFormValues,
+  fields: FieldSpec[],
+  typeSlug: string,
+): Record<string, unknown> {
+  return {
+    type_slug: typeSlug,
+    canonical_name: values.canonical_name,
+    description: values.description || null,
+    aliases: parseAliases(values.aliases as string),
+    fields: pickFieldValues(values, fields),
+  };
 }

--- a/src/frontend/src/routes/Settings.module.css
+++ b/src/frontend/src/routes/Settings.module.css
@@ -30,6 +30,23 @@
   gap: var(--space-2);
 }
 
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-3);
+}
+
+.newBtn {
+  padding: 8px 14px;
+  background-color: var(--color-accent);
+  color: var(--color-background, #fff);
+  border: 0;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  cursor: pointer;
+}
+
 .card {
   background-color: var(--color-surface);
   border: 1px solid var(--color-border);
@@ -45,6 +62,21 @@
   align-items: baseline;
   gap: var(--space-2);
   justify-content: space-between;
+}
+
+.cardActions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.cardActions button {
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 4px);
+  cursor: pointer;
+  color: var(--color-text);
 }
 
 .slug {
@@ -64,23 +96,12 @@
   line-height: 1.5;
 }
 
-.fieldList {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-  margin-top: var(--space-1);
-}
-
 .fieldRow {
   display: flex;
   gap: var(--space-2);
   align-items: center;
   font-size: 0.85rem;
   color: var(--color-text);
-}
-
-.fieldName {
-  font-family: var(--font-mono, monospace);
 }
 
 .fieldType {
@@ -103,9 +124,72 @@
   line-height: 1.5;
 }
 
-.placeholder {
+.editor {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.formRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2);
+}
+
+.editorField {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.editorField label {
+  font-size: 0.8rem;
+  font-weight: 600;
   color: var(--color-text-muted);
+}
+
+.editorField input,
+.editorField textarea {
+  padding: 8px 10px;
   font-size: 0.9rem;
-  margin-top: var(--space-3);
-  font-style: italic;
+  background-color: var(--color-surface-alt, var(--color-surface));
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 4px);
+  font-family: inherit;
+}
+
+.editorActions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.editorActions .primary {
+  padding: 8px 14px;
+  background-color: var(--color-accent);
+  color: var(--color-background, #fff);
+  border: 0;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.editorActions .secondary {
+  padding: 8px 14px;
+  background-color: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.error {
+  color: var(--color-danger, #c93030);
+  font-size: 0.85rem;
 }

--- a/src/frontend/src/routes/Settings.tsx
+++ b/src/frontend/src/routes/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import useSWR from "swr";
-import { fetcher } from "../api/client";
+import { ApiError, api } from "../api/client";
+import { useTypes } from "../api/useTypes";
 import type {
   EntityTypeDef,
   FieldSpec,
@@ -9,138 +9,564 @@ import type {
 import PageHeader from "../components/PageHeader";
 import Badge from "../components/Badge";
 import EmptyState from "../components/EmptyState";
+import FieldSpecEditor from "../components/FieldSpecEditor";
 import styles from "./Settings.module.css";
 
 type Tab = "entities" | "relations";
 
+type EditState =
+  | { kind: "none" }
+  | { kind: "new"; tab: Tab }
+  | { kind: "edit"; tab: Tab; slug: string };
+
 export default function Settings() {
   const [tab, setTab] = useState<Tab>("entities");
+  const [edit, setEdit] = useState<EditState>({ kind: "none" });
+  const { entityTypes, relationTypes, refresh } = useTypes();
 
-  const { data: entityTypes } = useSWR<EntityTypeDef[]>(
-    "/api/types/entities",
-    fetcher,
-  );
-  const { data: relationTypes } = useSWR<RelationTypeDef[]>(
-    "/api/types/relations",
-    fetcher,
-  );
+  const editing =
+    edit.kind === "edit"
+      ? (edit.tab === "entities"
+          ? (entityTypes ?? []).find((t) => t.slug === edit.slug)
+          : (relationTypes ?? []).find((t) => t.slug === edit.slug)) ?? null
+      : null;
 
   return (
     <div>
       <PageHeader
         title="Settings"
-        subtitle="Entity / Relation type registry (read-only in Stage 1)"
+        subtitle="Entity / Relation 型レジストリ"
       />
 
       <div className={styles.tabs}>
         <button
           className={tab === "entities" ? `${styles.tab} ${styles.tabActive}` : styles.tab}
-          onClick={() => setTab("entities")}
+          onClick={() => {
+            setTab("entities");
+            setEdit({ kind: "none" });
+          }}
         >
           Entity types ({entityTypes?.length ?? 0})
         </button>
         <button
           className={tab === "relations" ? `${styles.tab} ${styles.tabActive}` : styles.tab}
-          onClick={() => setTab("relations")}
+          onClick={() => {
+            setTab("relations");
+            setEdit({ kind: "none" });
+          }}
         >
           Relation types ({relationTypes?.length ?? 0})
         </button>
       </div>
 
-      {tab === "entities" && <EntityTypeList items={entityTypes} />}
-      {tab === "relations" && <RelationTypeList items={relationTypes} />}
+      <div className={styles.toolbar}>
+        <div />
+        <button
+          className={styles.newBtn}
+          onClick={() => setEdit({ kind: "new", tab })}
+        >
+          + New {tab === "entities" ? "entity" : "relation"} type
+        </button>
+      </div>
 
-      <p className={styles.placeholder}>
-        編集 UI は Stage 4 で追加されます。Stage 1 は登録済みの型を確認するための画面です。
-      </p>
+      {edit.kind === "new" && edit.tab === tab && (
+        tab === "entities" ? (
+          <EntityTypeEditor
+            entityTypeSlugs={(entityTypes ?? []).map((t) => t.slug)}
+            initial={null}
+            onClose={() => setEdit({ kind: "none" })}
+            onSaved={() => {
+              refresh();
+              setEdit({ kind: "none" });
+            }}
+          />
+        ) : (
+          <RelationTypeEditor
+            entityTypeSlugs={(entityTypes ?? []).map((t) => t.slug)}
+            initial={null}
+            onClose={() => setEdit({ kind: "none" })}
+            onSaved={() => {
+              refresh();
+              setEdit({ kind: "none" });
+            }}
+          />
+        )
+      )}
+
+      {edit.kind === "edit" && edit.tab === tab && editing && (
+        tab === "entities" ? (
+          <EntityTypeEditor
+            entityTypeSlugs={(entityTypes ?? []).map((t) => t.slug)}
+            initial={editing as EntityTypeDef}
+            onClose={() => setEdit({ kind: "none" })}
+            onSaved={() => {
+              refresh();
+              setEdit({ kind: "none" });
+            }}
+          />
+        ) : (
+          <RelationTypeEditor
+            entityTypeSlugs={(entityTypes ?? []).map((t) => t.slug)}
+            initial={editing as RelationTypeDef}
+            onClose={() => setEdit({ kind: "none" })}
+            onSaved={() => {
+              refresh();
+              setEdit({ kind: "none" });
+            }}
+          />
+        )
+      )}
+
+      {tab === "entities" && (
+        <EntityTypeList
+          items={entityTypes}
+          onEdit={(slug) => setEdit({ kind: "edit", tab: "entities", slug })}
+          onDelete={async (slug) => {
+            await api.deleteRoute(`/api/types/entities/${slug}`);
+            refresh();
+          }}
+        />
+      )}
+      {tab === "relations" && (
+        <RelationTypeList
+          items={relationTypes}
+          onEdit={(slug) => setEdit({ kind: "edit", tab: "relations", slug })}
+          onDelete={async (slug) => {
+            await api.deleteRoute(`/api/types/relations/${slug}`);
+            refresh();
+          }}
+        />
+      )}
     </div>
   );
 }
 
-function EntityTypeList({ items }: { items?: EntityTypeDef[] }) {
+// ---------------------------------------------------------------------------
+// Type editors
+// ---------------------------------------------------------------------------
+function EntityTypeEditor({
+  initial,
+  entityTypeSlugs,
+  onClose,
+  onSaved,
+}: {
+  initial: EntityTypeDef | null;
+  entityTypeSlugs: string[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const isNew = initial === null;
+  const [slug, setSlug] = useState(initial?.slug ?? "");
+  const [label, setLabel] = useState(initial?.label ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [extractionHint, setExtractionHint] = useState(
+    initial?.extraction_hint ?? "",
+  );
+  const [fieldsSchema, setFieldsSchema] = useState<FieldSpec[]>(
+    initial?.fields_schema ?? [],
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    const payload = {
+      slug: slug.trim(),
+      label: label.trim(),
+      description: description.trim() || null,
+      extraction_hint: extractionHint.trim() || null,
+      fields_schema: fieldsSchema,
+    };
+    try {
+      if (isNew) {
+        await api.post("/api/types/entities", payload);
+      } else {
+        await api.put(`/api/types/entities/${initial!.slug}`, payload);
+      }
+      onSaved();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form className={styles.editor} onSubmit={submit}>
+      <div className={styles.formRow}>
+        <div className={styles.editorField}>
+          <label>slug (snake_case, unique)</label>
+          <input
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            disabled={!isNew}
+            placeholder="e.g. meeting_topic"
+            required
+          />
+        </div>
+        <div className={styles.editorField}>
+          <label>label (表示名)</label>
+          <input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="議題"
+            required
+          />
+        </div>
+      </div>
+      <div className={styles.editorField}>
+        <label>description</label>
+        <textarea
+          rows={2}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+      <div className={styles.editorField}>
+        <label>LLM extraction hint (200 字程度推奨)</label>
+        <textarea
+          rows={2}
+          value={extractionHint}
+          onChange={(e) => setExtractionHint(e.target.value)}
+          placeholder="どんなときにこの型を作るか、LLM に伝える一文"
+        />
+      </div>
+      <div className={styles.editorField}>
+        <label>fields</label>
+        <FieldSpecEditor
+          value={fieldsSchema}
+          onChange={setFieldsSchema}
+          refTypeSlugs={entityTypeSlugs}
+        />
+      </div>
+      {error && <div className={styles.error}>{error}</div>}
+      <div className={styles.editorActions}>
+        <button type="submit" className={styles.primary} disabled={submitting}>
+          {submitting ? "..." : isNew ? "Create" : "Save"}
+        </button>
+        <button type="button" className={styles.secondary} onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function RelationTypeEditor({
+  initial,
+  entityTypeSlugs,
+  onClose,
+  onSaved,
+}: {
+  initial: RelationTypeDef | null;
+  entityTypeSlugs: string[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const isNew = initial === null;
+  const [slug, setSlug] = useState(initial?.slug ?? "");
+  const [label, setLabel] = useState(initial?.label ?? "");
+  const [inverseLabel, setInverseLabel] = useState(initial?.inverse_label ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [extractionHint, setExtractionHint] = useState(
+    initial?.extraction_hint ?? "",
+  );
+  const [sourceTypeSlug, setSourceTypeSlug] = useState(
+    initial?.source_type_slug ?? "",
+  );
+  const [targetTypeSlug, setTargetTypeSlug] = useState(
+    initial?.target_type_slug ?? "",
+  );
+  const [fieldsSchema, setFieldsSchema] = useState<FieldSpec[]>(
+    initial?.fields_schema ?? [],
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    const payload = {
+      slug: slug.trim(),
+      label: label.trim(),
+      inverse_label: inverseLabel.trim() || null,
+      description: description.trim() || null,
+      source_type_slug: sourceTypeSlug || null,
+      target_type_slug: targetTypeSlug || null,
+      extraction_hint: extractionHint.trim() || null,
+      fields_schema: fieldsSchema,
+    };
+    try {
+      if (isNew) {
+        await api.post("/api/types/relations", payload);
+      } else {
+        await api.put(`/api/types/relations/${initial!.slug}`, payload);
+      }
+      onSaved();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form className={styles.editor} onSubmit={submit}>
+      <div className={styles.formRow}>
+        <div className={styles.editorField}>
+          <label>slug</label>
+          <input
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            disabled={!isNew}
+            placeholder="e.g. blocks"
+            required
+          />
+        </div>
+        <div className={styles.editorField}>
+          <label>label</label>
+          <input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            required
+          />
+        </div>
+      </div>
+      <div className={styles.formRow}>
+        <div className={styles.editorField}>
+          <label>source type slug (任意)</label>
+          <select
+            value={sourceTypeSlug}
+            onChange={(e) => setSourceTypeSlug(e.target.value)}
+          >
+            <option value="">(any)</option>
+            {entityTypeSlugs.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className={styles.editorField}>
+          <label>target type slug (任意)</label>
+          <select
+            value={targetTypeSlug}
+            onChange={(e) => setTargetTypeSlug(e.target.value)}
+          >
+            <option value="">(any)</option>
+            {entityTypeSlugs.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className={styles.editorField}>
+        <label>inverse label (e.g. "managed by" の逆向き名)</label>
+        <input
+          value={inverseLabel}
+          onChange={(e) => setInverseLabel(e.target.value)}
+        />
+      </div>
+      <div className={styles.editorField}>
+        <label>description</label>
+        <textarea
+          rows={2}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+      <div className={styles.editorField}>
+        <label>LLM extraction hint</label>
+        <textarea
+          rows={2}
+          value={extractionHint}
+          onChange={(e) => setExtractionHint(e.target.value)}
+        />
+      </div>
+      <div className={styles.editorField}>
+        <label>fields (relations rarely need any)</label>
+        <FieldSpecEditor
+          value={fieldsSchema}
+          onChange={setFieldsSchema}
+          refTypeSlugs={entityTypeSlugs}
+        />
+      </div>
+      {error && <div className={styles.error}>{error}</div>}
+      <div className={styles.editorActions}>
+        <button type="submit" className={styles.primary} disabled={submitting}>
+          {submitting ? "..." : isNew ? "Create" : "Save"}
+        </button>
+        <button type="button" className={styles.secondary} onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Listings
+// ---------------------------------------------------------------------------
+function EntityTypeList({
+  items,
+  onEdit,
+  onDelete,
+}: {
+  items: EntityTypeDef[] | undefined;
+  onEdit: (slug: string) => void;
+  onDelete: (slug: string) => Promise<void>;
+}) {
   if (!items) return null;
   if (items.length === 0) return <EmptyState title="No entity types defined" />;
   return (
     <div className={styles.list}>
       {items.map((t) => (
-        <article key={t.slug} className={styles.card}>
-          <div className={styles.cardHead}>
-            <div>
-              <span className={styles.label}>{t.label}</span>{" "}
-              <span className={styles.slug}>{t.slug}</span>
-            </div>
-            {t.is_builtin && <Badge tone="muted">built-in</Badge>}
-          </div>
-          {t.description && <div className={styles.description}>{t.description}</div>}
-          <FieldSchemaList fields={t.fields_schema} />
-          {t.extraction_hint && (
-            <div className={styles.hint}>
-              <strong>LLM hint:</strong> {t.extraction_hint}
-            </div>
-          )}
-        </article>
+        <TypeCard
+          key={t.slug}
+          slug={t.slug}
+          label={t.label}
+          description={t.description}
+          isBuiltin={t.is_builtin}
+          extractionHint={t.extraction_hint}
+          fields={t.fields_schema}
+          extraMeta={null}
+          onEdit={() => onEdit(t.slug)}
+          onDelete={
+            t.is_builtin ? undefined : async () => {
+              if (!confirm(`型 "${t.slug}" を削除しますか？`)) return;
+              try {
+                await onDelete(t.slug);
+              } catch (err) {
+                alert(err instanceof ApiError ? err.message : String(err));
+              }
+            }
+          }
+        />
       ))}
     </div>
   );
 }
 
-function RelationTypeList({ items }: { items?: RelationTypeDef[] }) {
+function RelationTypeList({
+  items,
+  onEdit,
+  onDelete,
+}: {
+  items: RelationTypeDef[] | undefined;
+  onEdit: (slug: string) => void;
+  onDelete: (slug: string) => Promise<void>;
+}) {
   if (!items) return null;
   if (items.length === 0) return <EmptyState title="No relation types defined" />;
   return (
     <div className={styles.list}>
       {items.map((t) => (
-        <article key={t.slug} className={styles.card}>
-          <div className={styles.cardHead}>
-            <div>
-              <span className={styles.label}>{t.label}</span>{" "}
-              <span className={styles.slug}>{t.slug}</span>
+        <TypeCard
+          key={t.slug}
+          slug={t.slug}
+          label={t.label}
+          description={t.description}
+          isBuiltin={t.is_builtin}
+          extractionHint={t.extraction_hint}
+          fields={t.fields_schema}
+          extraMeta={
+            <div className={styles.fieldRow}>
+              <span className={styles.fieldType}>source:</span>
+              <span>{t.source_type_slug ?? "any"}</span>
+              <span className={styles.fieldType}>→ target:</span>
+              <span>{t.target_type_slug ?? "any"}</span>
               {t.inverse_label && (
-                <span className={styles.slug}> ⇄ {t.inverse_label}</span>
+                <span className={styles.fieldType}>
+                  inverse: {t.inverse_label}
+                </span>
               )}
             </div>
-            {t.is_builtin && <Badge tone="muted">built-in</Badge>}
-          </div>
-          {t.description && <div className={styles.description}>{t.description}</div>}
-          <div className={styles.fieldRow}>
-            <span className={styles.fieldType}>source:</span>
-            <span className={styles.fieldName}>{t.source_type_slug ?? "any"}</span>
-            <span className={styles.fieldType}>→ target:</span>
-            <span className={styles.fieldName}>{t.target_type_slug ?? "any"}</span>
-          </div>
-          <FieldSchemaList fields={t.fields_schema} />
-          {t.extraction_hint && (
-            <div className={styles.hint}>
-              <strong>LLM hint:</strong> {t.extraction_hint}
-            </div>
-          )}
-        </article>
+          }
+          onEdit={() => onEdit(t.slug)}
+          onDelete={
+            t.is_builtin ? undefined : async () => {
+              if (!confirm(`関係型 "${t.slug}" を削除しますか？`)) return;
+              try {
+                await onDelete(t.slug);
+              } catch (err) {
+                alert(err instanceof ApiError ? err.message : String(err));
+              }
+            }
+          }
+        />
       ))}
     </div>
   );
 }
 
-function FieldSchemaList({ fields }: { fields: FieldSpec[] }) {
-  if (fields.length === 0) {
-    return <div className={styles.empty}>(no custom fields)</div>;
-  }
+function TypeCard({
+  slug,
+  label,
+  description,
+  isBuiltin,
+  extractionHint,
+  fields,
+  extraMeta,
+  onEdit,
+  onDelete,
+}: {
+  slug: string;
+  label: string;
+  description: string | null;
+  isBuiltin: boolean;
+  extractionHint: string | null;
+  fields: FieldSpec[];
+  extraMeta: React.ReactNode;
+  onEdit: () => void;
+  onDelete?: () => void;
+}) {
   return (
-    <div className={styles.fieldList}>
-      {fields.map((f) => (
-        <div key={f.name} className={styles.fieldRow}>
-          <span className={styles.fieldName}>{f.name}</span>
-          <span className={styles.fieldType}>: {f.type}</span>
-          {f.required && <Badge tone="warning">required</Badge>}
-          {f.type === "enum" && f.options && (
-            <span className={styles.fieldType}>[{f.options.join(", ")}]</span>
-          )}
-          {f.default !== undefined && f.default !== null && (
-            <span className={styles.fieldType}>
-              default: {String(f.default)}
-            </span>
-          )}
+    <article className={styles.card}>
+      <div className={styles.cardHead}>
+        <div>
+          <span className={styles.label}>{label}</span>{" "}
+          <span className={styles.slug}>{slug}</span>{" "}
+          {isBuiltin && <Badge tone="muted">built-in</Badge>}
         </div>
-      ))}
-    </div>
+        <div className={styles.cardActions}>
+          <button onClick={onEdit}>Edit</button>
+          {onDelete && <button onClick={onDelete}>Delete</button>}
+        </div>
+      </div>
+      {description && <div className={styles.description}>{description}</div>}
+      {extraMeta}
+      {fields.length === 0 ? (
+        <div className={styles.empty}>(no custom fields)</div>
+      ) : (
+        <div>
+          {fields.map((f) => (
+            <div key={f.name} className={styles.fieldRow}>
+              <span style={{ fontFamily: "var(--font-mono, monospace)" }}>
+                {f.name}
+              </span>
+              <span className={styles.fieldType}>: {f.type}</span>
+              {f.required && <Badge tone="warning">required</Badge>}
+              {f.type === "enum" && f.options && (
+                <span className={styles.fieldType}>
+                  [{f.options.join(", ")}]
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {extractionHint && (
+        <div className={styles.hint}>
+          <strong>LLM hint:</strong> {extractionHint}
+        </div>
+      )}
+    </article>
   );
 }


### PR DESCRIPTION
…ge 4)

The Settings and Entities pages are now schema-driven end-to-end. Users can define new entity types (including arbitrary FieldSpec[] payloads and an LLM extraction hint), then create instances of those types through the same UI that renders their fields. No hardcoded TODO or fixed enum survives in the React tree.

New components:
- ``api/useTypes`` — shared SWR cache over /api/types/{entities,relations}. Long dedupingInterval; ``refresh()`` mutates both keys after edits.
- ``components/DynamicForm`` — controlled form rendered from a FieldSpec[]. Switches per type (string / text / int / float / bool / date / datetime / enum / url / ref). ``ref`` widgets fetch a candidate entity list. Surfaces required-field errors and rejects empty required submissions.
- ``components/FieldSpecEditor`` — meta-form for FieldSpec[]: add / remove / reorder fields, enum options textarea, ref_type_slug picker, default value.

Pages:
- ``routes/Settings`` rewritten for full CRUD on both type registries. New / Edit / Delete inline (built-ins reject deletion via the existing 409).
- ``routes/Entities`` rewritten with type chips (one per registered entity type), per-type list view, ``+ New <type>`` button that opens DynamicForm, detail panel with inline edit + delete, and an incoming/outgoing relations section keyed by /api/relations.

``api/client`` gains ``put`` and ``deleteRoute`` helpers used by the new CRUD flows. The dashboard's Tasks panel keeps working unchanged because it already reads /api/entities?type_slug=task.

Verification: pnpm tsc --noEmit clean, pnpm build clean, backend ``uv run pytest`` 287 passing (no Python changes in this stage).