### PR TITLE
fix(extraction): accept null relation target so honest LLM output sur…

### DIFF
--- a/src/docdb/llm/prompts.py
+++ b/src/docdb/llm/prompts.py
@@ -81,7 +81,10 @@ def build_extraction_system_prompt(
         if relation_types:
             parts.append(
                 "8. relations[] の `source` / `target` は同じドキュメントの entities[] "
-                "に出てくる (type, name) を指す。解決できないものは出力しない。"
+                "に出てくる (type, name) を指す。`source` は必須。"
+                "`target` が本文から特定できない場合は `null` を入れる "
+                "(該当 relation はパイプライン側で除外される)。"
+                "endpoints を捏造しない。"
             )
 
     assembled = "\n".join(parts)

--- a/src/docdb/typing/dynamic_model.py
+++ b/src/docdb/typing/dynamic_model.py
@@ -19,7 +19,7 @@ Output envelope:
         "relations": [                            // only when ≥1 relation type
             {"type": "assigned_to",
              "source": {"type": "task", "name": "..."},
-             "target": {"type": "person", "name": "..."},
+             "target": {"type": "person", "name": "..."},  // or null when unknown
              "fields": {}}
         ]
     }
@@ -66,7 +66,12 @@ class ExtractedRelationBase(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     source: ExtractedEntityRef
-    target: ExtractedEntityRef
+    # target is intentionally nullable: small LLMs honestly emit
+    # `{"target": null}` when the source text does not name a counterpart
+    # (e.g. an unassigned task). Forcing it would push models to either
+    # fabricate a target or drop the whole extraction; both are worse than
+    # letting the normaliser discard the dangling relation downstream.
+    target: ExtractedEntityRef | None = None
     fields: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/tests/docdb/test_config.py
+++ b/tests/docdb/test_config.py
@@ -7,7 +7,7 @@ def test_defaults_use_qwen3_4b_for_both_extract_and_agent() -> None:
     # opt-in via DOCDB_AGENT_MODEL.
     from docdb.config import Settings
 
-    s = Settings()
+    s = Settings(_env_file=None)
     assert s.extract_model == "qwen3:4b"
     assert s.agent_model == "qwen3:4b"
     assert s.embed_model == "bge-m3"

--- a/tests/docdb/test_dynamic_extraction.py
+++ b/tests/docdb/test_dynamic_extraction.py
@@ -238,6 +238,43 @@ class TestNormalizerStage3:
         assert norm.relations == []
         assert any(d.kind == "unresolved_relation" for d in norm.drops)
 
+    def test_relation_with_null_target_is_accepted_then_dropped(self) -> None:
+        # Regression: small LLMs honestly emit ``target: null`` when the source
+        # text does not name a counterpart. Pydantic must accept the payload so
+        # that the rest of the extraction (entities!) survives; the normaliser
+        # then drops the dangling relation as ``unresolved_relation``.
+        Model = build_extraction_model(
+            entity_type_slugs=["person", "task"],
+            relation_type_slugs=["assigned_to"],
+            registry_hash="null-target-test",
+        )
+        payload = Model(
+            entities=[
+                {"type": "task", "name": "write spec",
+                 "fields": {"status": "pending", "priority": "medium"}},
+                {"type": "person", "name": "Tanaka"},
+            ],
+            relations=[
+                {"type": "assigned_to",
+                 "source": {"type": "task", "name": "write spec"},
+                 "target": None},
+            ],
+        )
+        # Sanity: schema accepted the null target rather than raising.
+        assert payload.relations[0].target is None
+
+        norm = normalize_extraction(
+            payload,
+            document_id="doc-1",
+            entity_type_slugs={"person", "task"},
+            relation_type_slugs={"assigned_to"},
+        )
+        # The orphan relation is dropped, but both entities survive — that is
+        # the whole point of allowing null targets at the schema layer.
+        assert norm.relations == []
+        assert any(d.kind == "unresolved_relation" for d in norm.drops)
+        assert {e.canonical_name for e in norm.entities} == {"write spec", "Tanaka"}
+
     def test_extract_relations_false_skips_relations(self) -> None:
         payload = self._make_payload(
             entities=[


### PR DESCRIPTION
…vives

Small LLMs (e.g. granite4.1:3b) faithfully emit `target: null` when the source text does not name a counterpart for a relation (an unassigned task, a meeting with no stated location, etc.). The strict `ExtractedEntityRef` requirement turned that into a pydantic ValidationError for the entire ExtractionResult, taking person/org/place entities and tags down with the offending relation -- after 3 instructor retries the whole payload was discarded and only the deterministic `task_checkbox` extractor produced anything. On an 8-file fixture this manifested as entities_total=35 (all task), relations=0, tags=5; after the fix the same model + same corpus yields 46 entities across 4 types, 14 tags, and the relation that did have both endpoints.

The schema is the actually-wrong actor: a relation type whose target is unknown in the source is information we should be tolerant of rather than force the model to fabricate or to silently omit. The normaliser already drops unresolved relations (`_build_relations` returns `unresolved_relation` drops), so DB FK integrity is unchanged -- we just stop discarding the rest of the payload alongside.

- ExtractedRelationBase.target: ExtractedEntityRef | None = None
- prompt rule 8 now states that target may be null when not in the text
- test_dynamic_extraction covers the new contract end-to-end
- test_defaults_use_qwen3_4b uses `_env_file=None` so a local .env (now the documented way to override the model) doesn't bleed into the defaults test