### PR TITLE
feat(agent): entity-first prompt, dynamic type catalog, text_to_sql tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ uv sync --extra test --extra ingestion
 ### 2. Ollama (ローカル LLM / embedding)
 
 ```bash
-ollama pull qwen3:4b      # agent / extraction
+ollama pull granite4.1:3b  # agent / extraction (default)
 ollama pull bge-m3        # embeddings (1024 dims)
 ```
 

--- a/src/docdb/agent/toolbox.py
+++ b/src/docdb/agent/toolbox.py
@@ -29,7 +29,7 @@ from docdb.models import Citation, Document, Entity, Relation
 from docdb.search import direct
 from docdb.search.hybrid import hybrid_search
 from docdb.search.sql_guard import UnsafeQueryError, validate_readonly_sql
-from docdb.search.text2sql import ALLOWED_TABLES
+from docdb.search.text2sql import ALLOWED_TABLES, run_text2sql
 from docdb.typing.registry import list_entity_types, list_relation_types
 
 
@@ -257,12 +257,38 @@ class Toolbox:
                 },
             ),
             ToolSpec(
+                name="text_to_sql",
+                description=(
+                    "Translate a natural-language question into a safe read-only "
+                    "SELECT against documents / entities / relations / tags and "
+                    "run it. Prefer this over `execute_readonly_sql` for any "
+                    "cross-table aggregation, count, LIKE search, or schema-aware "
+                    "filter — the underlying prompt is given the full schema, so "
+                    "column names won't be hallucinated. The natural-language "
+                    "question is passed straight through; do not write SQL here."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "question": {
+                            "type": "string",
+                            "description": "The natural-language question to translate into SQL.",
+                        }
+                    },
+                    "required": ["question"],
+                },
+            ),
+            ToolSpec(
                 name="execute_readonly_sql",
                 description=(
                     "Last-resort escape hatch: execute a hand-crafted SELECT "
-                    "against the documents/entities/relations/tags schema. The "
-                    "SQL is validated by the same guard the rest of the "
-                    "system uses (SELECT-only, allowlisted tables, auto LIMIT)."
+                    "against the schema. Prefer `text_to_sql` unless you have a "
+                    "very specific query you want to run verbatim. Tables: "
+                    "documents(id, title, raw_text, summary, doc_type, ...), "
+                    "entities(id, type_slug, canonical_name, fields JSON), "
+                    "relations(id, type_slug, source_entity_id, target_entity_id). "
+                    "FTS via documents_fts MATCH 'word'. SELECT-only, allowlisted "
+                    "tables, auto LIMIT."
                 ),
                 parameters={
                     "type": "object",
@@ -282,6 +308,7 @@ class Toolbox:
             "search_entities": self._search_entities,
             "get_entity_documents": self._get_entity_documents,
             "search_relations": self._search_relations,
+            "text_to_sql": self._text_to_sql,
             "execute_readonly_sql": self._execute_readonly_sql,
         }
         return specs, handlers
@@ -400,6 +427,21 @@ class Toolbox:
                 top_k=top_k,
             )
         ]
+
+    def _text_to_sql(self, question: str) -> dict:
+        result = run_text2sql(
+            self.conn,
+            question,
+            self.llm,
+            max_limit=self.max_sql_limit,
+            max_rows=self.max_sql_limit,
+        )
+        return {
+            "sql": result.validated_sql or result.sql,
+            "reasoning": result.reasoning,
+            "rows": result.rows,
+            "error": result.error,
+        }
 
     def _execute_readonly_sql(self, sql: str) -> dict:
         try:

--- a/src/docdb/cli.py
+++ b/src/docdb/cli.py
@@ -30,7 +30,9 @@ from docdb.ingestion import (
 )
 from docdb.llm.base import LLMProtocol
 from docdb.llm.client import LLM
+from docdb.llm.prompts import build_agent_system_prompt
 from docdb.schema.connection import connection, init_db
+from docdb.typing.registry import list_entity_types, list_relation_types
 from docdb.search.direct import (
     count_documents,
     list_doc_types,
@@ -231,7 +233,17 @@ def ask(
     llm = ctx.obj["llm_factory"](settings)
     with connection(settings.db_path) as conn:
         toolbox = Toolbox(conn, llm)
-        agent = SearchAgent(toolbox=toolbox, llm=llm, max_iters=max_iters)
+        system_prompt = build_agent_system_prompt(
+            list_entity_types(conn),
+            list_relation_types(conn),
+            max_bytes=settings.agent_prompt_max_bytes,
+        )
+        agent = SearchAgent(
+            toolbox=toolbox,
+            llm=llm,
+            max_iters=max_iters,
+            system_prompt=system_prompt,
+        )
         result = agent.run(question)
 
     if result.error:

--- a/src/docdb/config.py
+++ b/src/docdb/config.py
@@ -16,8 +16,8 @@ class Settings(BaseSettings):
     )
 
     ollama_base_url: str = "http://localhost:11434/v1"
-    extract_model: str = "qwen3:4b"
-    agent_model: str = "qwen3:4b"
+    extract_model: str = "granite4.1:3b"
+    agent_model: str = "granite4.1:3b"
     embed_model: str = "bge-m3"
     embed_dim: int = 1024
     keep_alive: str = "5m"
@@ -34,6 +34,7 @@ class Settings(BaseSettings):
     # rebuilding the type registry.
     extract_relations: bool = True
     extraction_prompt_max_bytes: int = Field(default=30_000, ge=2_000, le=200_000)
+    agent_prompt_max_bytes: int = Field(default=20_000, ge=2_000, le=150_000)
 
 
 @lru_cache(maxsize=1)

--- a/src/docdb/llm/client.py
+++ b/src/docdb/llm/client.py
@@ -10,8 +10,8 @@ exposes three operations:
 * ``embed``: vector embeddings via the configured ``embed_model``.
 
 The ``keep_alive`` setting is forwarded through ``extra_body`` so
-qwen3 stays warm between successive requests (Ollama-specific knob
-that survives the OpenAI compatibility layer).
+the local model stays warm between successive requests
+(Ollama-specific knob that survives the OpenAI compatibility layer).
 """
 
 from __future__ import annotations

--- a/src/docdb/llm/prompts.py
+++ b/src/docdb/llm/prompts.py
@@ -24,6 +24,7 @@ from docdb.typing.registry import EntityTypeDef, RelationTypeDef
 
 
 EXTRACTION_PROMPT_MAX_BYTES = 30_000
+AGENT_PROMPT_MAX_BYTES = 20_000
 
 
 EXTRACTION_SYSTEM_BASE = (
@@ -248,20 +249,91 @@ def build_text2sql_user_prompt(question: str) -> str:
 # ---------------------------------------------------------------------------
 # Search agent
 # ---------------------------------------------------------------------------
-AGENT_SYSTEM = (
+AGENT_SYSTEM_BASE = (
     "あなたは個人 Markdown メモに対する検索エージェントです。\n"
     "提供されたツールのみを使って情報を探し、ユーザーの質問に日本語で簡潔に答えます。\n"
     "\n"
+    "この個人ノートは property graph として整理されており、人物・組織・タスク・場所などは\n"
+    "事前に entity として抽出され、`type_slug` でカテゴリ化されている。質問に固有名詞や\n"
+    "型ベースの条件が含まれる場合、全文検索より entity 系ツールの方が速く正確に辿れる。\n"
+    "\n"
     "進め方:\n"
-    "1. まず `search_documents` で広く検索する (3 文字以上の語を使う; 日本語FTS5の制約)。\n"
-    "2. 言い換えや同義語が重要な質問では `hybrid=true` を渡す。\n"
-    "3. 関連文書が見つかったら `get_document` で本文を確認する。\n"
-    "4. 集計や横断条件には `execute_readonly_sql` を使う (SELECT のみ実行可能)。\n"
-    "5. 人物・組織・タスクなど型に依存する質問は `list_entity_types` で何が登録されているか確認してから `search_entities` を呼ぶ。\n"
-    "6. エンティティ間の関係は `search_relations` で辿る。\n"
+    "1. 質問に **固有名詞** (人名・組織名・カタカナ語・略号・カギカッコ付き固有名詞など)\n"
+    "   が含まれるなら、まず `search_entities` で該当 entity を引く。\n"
+    "   後ろに示す entity 型カタログから妥当な `type_slug` を絞ると精度が上がる。\n"
+    "   見つかったら `get_entity_documents` で言及ドキュメントを取得する。\n"
+    "2. 質問が **型ベース** (例: 「未完了のタスクは？」「最近の会議は？」) なら、\n"
+    "   `search_entities` (`type_slug` 指定) や、件数集計が必要なら `execute_readonly_sql` を使う。\n"
+    "3. **エンティティ間の関係** (担当者・所属・親子) を辿る質問は `search_relations` を使う。\n"
+    "4. 上記で当たりが付かないか、自由語句での意味検索が必要なら `search_documents` を使う\n"
+    "   (3 文字以上; 言い換えに弱いと感じたら `hybrid=true`)。本文確認は `get_document`。\n"
+    "5. 横断条件・集計・LIKE 検索・スキーマ依存のフィルタなど SQL が要る場面では\n"
+    "   `text_to_sql` を使う (質問文をそのまま渡せばスキーマ込みで SELECT を生成して実行する)。\n"
+    "   特定の SQL を自分で書きたいときだけ `execute_readonly_sql` を使う\n"
+    "   (テーブル: documents(id, title, raw_text, summary, doc_type, …)、\n"
+    "   entities(id, type_slug, canonical_name, fields JSON, …)、relations(id, type_slug,\n"
+    "   source_entity_id, target_entity_id, …)。`body` ではなく `raw_text`)。\n"
+    "6. 型カタログを最新化したくなったら `list_entity_types` / `list_relation_types` を呼ぶ\n"
+    "   (通常は下のカタログで十分)。\n"
     "\n"
     "ルール:\n"
     "- ツール結果に書かれていない情報を捏造しない。資料に存在しなければ「分かりません」と答える。\n"
     "- 回答末尾に出典を `[doc:document_id]` の形式で列挙する。\n"
     "- 不要なツール呼び出しを避ける。十分な情報が揃ったら速やかに最終回答を返す。"
 )
+
+# Back-compat: external callers and existing tests import AGENT_SYSTEM directly.
+AGENT_SYSTEM = AGENT_SYSTEM_BASE
+
+
+def build_agent_system_prompt(
+    entity_types: list[EntityTypeDef],
+    relation_types: list[RelationTypeDef],
+    *,
+    max_bytes: int = AGENT_PROMPT_MAX_BYTES,
+) -> str:
+    """Assemble the agent system prompt with the live type catalogue appended.
+
+    The agent only needs slug / label / short description to steer
+    ``search_entities`` and ``search_relations`` toward the right ``type_slug``.
+    Field schemas and extraction hints (used on the extraction side) are
+    deliberately omitted to keep the prompt small at inference time.
+
+    Hard-capped at ``max_bytes`` UTF-8 bytes; if the assembled prompt grows
+    past the cap, trailing catalogue entries are dropped (same approach as
+    ``build_extraction_system_prompt``).
+    """
+    parts: list[str] = [AGENT_SYSTEM_BASE, ""]
+
+    if entity_types:
+        parts.append("# 登録済みの entity 型 (slug : label)")
+        for t in entity_types:
+            parts.append(_render_entity_type_lite(t))
+        parts.append("")
+
+    if relation_types and entity_types:
+        parts.append("# 登録済みの relation 型 (slug : label, source → target)")
+        for t in relation_types:
+            parts.append(_render_relation_type_lite(t))
+        parts.append("")
+
+    assembled = "\n".join(parts)
+    if len(assembled.encode("utf-8")) <= max_bytes:
+        return assembled
+
+    return _truncate_to_fit(parts, max_bytes)
+
+
+def _render_entity_type_lite(t: EntityTypeDef) -> str:
+    head = f"- `{t.slug}` : {t.label}"
+    if t.description:
+        head += f" — {t.description}"
+    return head
+
+
+def _render_relation_type_lite(t: RelationTypeDef) -> str:
+    endpoints = f"{t.source_type_slug or 'any'} → {t.target_type_slug or 'any'}"
+    head = f"- `{t.slug}` : {t.label} ({endpoints})"
+    if t.description:
+        head += f" — {t.description}"
+    return head

--- a/src/server/routes/ask.py
+++ b/src/server/routes/ask.py
@@ -7,6 +7,8 @@ from flask import Blueprint, current_app, jsonify, request
 from docdb.agent.loop import SearchAgent
 from docdb.agent.toolbox import Toolbox
 from docdb.config import Settings
+from docdb.llm.prompts import build_agent_system_prompt
+from docdb.typing.registry import list_entity_types, list_relation_types
 
 from server.context import get_conn, get_llm
 
@@ -29,7 +31,17 @@ def ask():
     conn = get_conn()
     llm = get_llm()
     toolbox = Toolbox(conn, llm, max_sql_limit=settings.sql_max_limit)
-    agent = SearchAgent(toolbox=toolbox, llm=llm, max_iters=max_iters)
+    system_prompt = build_agent_system_prompt(
+        list_entity_types(conn),
+        list_relation_types(conn),
+        max_bytes=settings.agent_prompt_max_bytes,
+    )
+    agent = SearchAgent(
+        toolbox=toolbox,
+        llm=llm,
+        max_iters=max_iters,
+        system_prompt=system_prompt,
+    )
     result = agent.run(question)
 
     return jsonify(

--- a/tests/docdb/test_config.py
+++ b/tests/docdb/test_config.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 
-def test_defaults_use_qwen3_4b_for_both_extract_and_agent() -> None:
-    # The default agent model is the safe side (4b) so memory-constrained
-    # machines do not implicitly load two models. Switching to qwen3:8b is
-    # opt-in via DOCDB_AGENT_MODEL.
+def test_defaults_use_granite4_1_for_both_extract_and_agent() -> None:
+    # Default is granite4.1:3b for both extraction and the agent; a larger
+    # model can be opted into via DOCDB_AGENT_MODEL / DOCDB_EXTRACT_MODEL.
     from docdb.config import Settings
 
     s = Settings(_env_file=None)
-    assert s.extract_model == "qwen3:4b"
-    assert s.agent_model == "qwen3:4b"
+    assert s.extract_model == "granite4.1:3b"
+    assert s.agent_model == "granite4.1:3b"
     assert s.embed_model == "bge-m3"
     assert s.embed_dim == 1024
 

--- a/tests/docdb/test_property_graph_agent.py
+++ b/tests/docdb/test_property_graph_agent.py
@@ -19,9 +19,21 @@ from docdb.agent.loop import SearchAgent
 from docdb.agent.toolbox import Toolbox
 from docdb.ingestion.store import DocumentStore
 from docdb.llm.fake import FakeLLM, StubChatCompletion
-from docdb.llm.prompts import AGENT_SYSTEM, DOCDB_SCHEMA_SUMMARY
+from docdb.llm.prompts import (
+    AGENT_PROMPT_MAX_BYTES,
+    AGENT_SYSTEM,
+    AGENT_SYSTEM_BASE,
+    DOCDB_SCHEMA_SUMMARY,
+    build_agent_system_prompt,
+)
 from docdb.models import Entity, entity_id_for
 from docdb.search.text2sql import ALLOWED_TABLES
+from docdb.typing.registry import (
+    EntityTypeDef,
+    RelationTypeDef,
+    list_entity_types,
+    list_relation_types,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +147,7 @@ def test_agent_system_lists_property_graph_tools() -> None:
     assert "list_entity_types" in AGENT_SYSTEM
     assert "search_entities" in AGENT_SYSTEM
     assert "search_relations" in AGENT_SYSTEM
+    assert "text_to_sql" in AGENT_SYSTEM
     # And it must NOT mention the removed Stage-2 ``list_todos`` tool.
     assert "list_todos" not in AGENT_SYSTEM
 
@@ -142,10 +155,77 @@ def test_agent_system_lists_property_graph_tools() -> None:
 def test_toolbox_specs_match_agent_system_advertised_tools(conn) -> None:
     toolbox = Toolbox(conn, FakeLLM())
     declared = {spec.name for spec in toolbox.specs()}
-    assert {"list_entity_types", "search_entities", "search_relations"}.issubset(
-        declared
-    )
+    assert {
+        "list_entity_types",
+        "search_entities",
+        "search_relations",
+        "text_to_sql",
+    }.issubset(declared)
     assert "list_todos" not in declared
+
+
+# ---------------------------------------------------------------------------
+# build_agent_system_prompt: dynamic type catalogue
+# ---------------------------------------------------------------------------
+class TestBuildAgentSystemPrompt:
+    def test_default_cap_is_20kb(self) -> None:
+        assert AGENT_PROMPT_MAX_BYTES == 20_000
+
+    def test_agent_system_alias_is_back_compat(self) -> None:
+        # External callers import AGENT_SYSTEM directly. It must stay equal to
+        # the base string after the rename.
+        assert AGENT_SYSTEM == AGENT_SYSTEM_BASE
+
+    def test_empty_registry_returns_base_only(self) -> None:
+        prompt = build_agent_system_prompt([], [])
+        # The base instructions are preserved verbatim.
+        assert AGENT_SYSTEM_BASE in prompt
+        # Catalogue headers only show up when types exist.
+        assert "登録済みの entity 型" not in prompt
+        assert "登録済みの relation 型" not in prompt
+
+    def test_catalogue_lists_entity_slug_and_label(self, conn: sqlite3.Connection) -> None:
+        entity_types = list_entity_types(conn)
+        prompt = build_agent_system_prompt(entity_types, [])
+        assert "登録済みの entity 型" in prompt
+        for t in entity_types:
+            assert f"`{t.slug}`" in prompt
+            assert t.label in prompt
+
+    def test_catalogue_omits_field_details(self, conn: sqlite3.Connection) -> None:
+        # The agent prompt is intentionally lean: no fields_schema dump.
+        task = next(t for t in list_entity_types(conn) if t.slug == "task")
+        prompt = build_agent_system_prompt([task], [])
+        # task has 'status' field on the extraction side, but the agent prompt
+        # should not enumerate per-field specs (keeps the prompt small).
+        assert "status (enum" not in prompt
+        assert "due_date (date" not in prompt
+
+    def test_relation_catalogue_shows_endpoints(self, conn: sqlite3.Connection) -> None:
+        entity_types = list_entity_types(conn)
+        relation_types = list_relation_types(conn)
+        if not relation_types:
+            pytest.skip("no relation types seeded in this fixture")
+        prompt = build_agent_system_prompt(entity_types, relation_types)
+        for t in relation_types:
+            assert f"`{t.slug}`" in prompt
+
+    def test_relations_skipped_when_no_entity_types(self) -> None:
+        rel = RelationTypeDef.model_validate(
+            {"slug": "assigned_to", "label": "担当", "fields_schema": []}
+        )
+        prompt = build_agent_system_prompt([], [rel])
+        # Without any entity types the relation catalogue is irrelevant noise.
+        assert "assigned_to" not in prompt
+
+    def test_byte_cap_truncates_rather_than_crashing(self, conn: sqlite3.Connection) -> None:
+        entity_types = list_entity_types(conn)
+        relation_types = list_relation_types(conn)
+        prompt = build_agent_system_prompt(
+            entity_types, relation_types, max_bytes=2_500
+        )
+        assert len(prompt.encode("utf-8")) <= 2_700
+        assert "省略" in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/docdb/test_toolbox.py
+++ b/tests/docdb/test_toolbox.py
@@ -20,6 +20,7 @@ import pytest
 
 from docdb.agent.toolbox import Toolbox
 from docdb.llm.fake import FakeLLM
+from docdb.search.text2sql import GeneratedSQL
 
 from tests.docdb.fixtures import SAMPLE_DOCS, SAMPLE_ENTITIES
 
@@ -172,6 +173,52 @@ def test_execute_readonly_sql_rejects_unsafe(toolbox: Toolbox) -> None:
     assert inv.succeeded  # no exception
     assert "error" in inv.result
     assert "unsafe sql" in inv.result["error"]
+
+
+# ---------------------------------------------------------------------------
+# text_to_sql
+# ---------------------------------------------------------------------------
+def test_text_to_sql_dispatches_to_run_text2sql(populated_db) -> None:
+    llm = FakeLLM(
+        extract_responses=[
+            GeneratedSQL(
+                sql="SELECT id FROM documents WHERE doc_type='memo'",
+                reasoning="filter memos by doc_type",
+            )
+        ]
+    )
+    tb = Toolbox(populated_db, llm)
+    inv = tb.invoke("text_to_sql", {"question": "メモだけ一覧して"})
+    assert inv.succeeded
+    assert inv.result["error"] is None
+    assert inv.result["reasoning"] == "filter memos by doc_type"
+    ids = {row["id"] for row in inv.result["rows"]}
+    assert ids == {SAMPLE_DOCS[0].id, SAMPLE_DOCS[4].id}
+
+
+def test_text_to_sql_surfaces_unsafe_sql_as_error(populated_db) -> None:
+    llm = FakeLLM(extract_responses=[GeneratedSQL(sql="DROP TABLE documents")])
+    tb = Toolbox(populated_db, llm)
+    inv = tb.invoke("text_to_sql", {"question": "drop everything"})
+    assert inv.succeeded  # the tool itself didn't raise
+    assert inv.result["error"] is not None
+    assert "unsafe sql" in inv.result["error"]
+    assert inv.result["rows"] == []
+
+
+def test_text_to_sql_surfaces_sqlite_error(populated_db) -> None:
+    # Column 'body' doesn't exist on the documents table — the same trap the
+    # agent fell into before this tool was wired up.
+    llm = FakeLLM(
+        extract_responses=[
+            GeneratedSQL(sql="SELECT id, body FROM documents WHERE body LIKE '%x%'")
+        ]
+    )
+    tb = Toolbox(populated_db, llm)
+    inv = tb.invoke("text_to_sql", {"question": "find x"})
+    assert inv.succeeded
+    assert inv.result["error"] is not None
+    assert "sqlite error" in inv.result["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three changes that cut iterations on property-graph questions:

- AGENT_SYSTEM reordered so search_entities is tried first when the question contains a proper noun. build_agent_system_prompt appends the live entity/relation type catalogue (slug + label) so the LLM can pass type_slug without first calling list_entity_types. Wired into /api/ask and the CLI; Settings gains agent_prompt_max_bytes (default 20KB) to cap the catalogue, mirroring extraction.
- text_to_sql tool exposed in Toolbox so the agent gets schema-aware SQL via run_text2sql instead of writing SELECTs by hand against the wrong column names. execute_readonly_sql is demoted to "last resort" with the schema sketched in its description.
- Default extract_model / agent_model switched from qwen3:4b to granite4.1:3b. The ACME smoke question now resolves in 3 iterations (was 7 before, 4 with qwen3 after the prompt rework).