### PR TITLE
Surface rewritten questions in agent trace for UI display

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,6 +47,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: src/frontend/package.json
 
       - uses: actions/setup-node@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,4 +62,4 @@ where = ["src"]
 # scripts/refresh_uv_exclude_newer.py (pre-commit + CI). The refresh
 # script only moves the date forward, so a manual bump here for an
 # urgent CVE fix will stick until time naturally catches up.
-exclude-newer = "2026-05-08T00:00:00Z"
+exclude-newer = "2026-05-09T00:00:00Z"

--- a/src/docdb/agent/loop.py
+++ b/src/docdb/agent/loop.py
@@ -46,6 +46,7 @@ class AgentTrace:
     arguments: dict[str, Any]
     result_preview: str = ""
     error: str | None = None
+    rewritten_question: str | None = None
 
     @property
     def succeeded(self) -> bool:
@@ -139,6 +140,12 @@ class SearchAgent:
                 if len(preview) > 500:
                     preview = preview[:500] + "…"
 
+                rewritten = (
+                    inv.result.get("rewritten_question")
+                    if isinstance(inv.result, dict)
+                    else None
+                )
+
                 trace.append(
                     AgentTrace(
                         iteration=iteration,
@@ -146,6 +153,7 @@ class SearchAgent:
                         arguments=inv.arguments,
                         result_preview=preview,
                         error=inv.error,
+                        rewritten_question=rewritten,
                     )
                 )
 

--- a/src/frontend/src/api/types.ts
+++ b/src/frontend/src/api/types.ts
@@ -145,6 +145,7 @@ export interface AgentTrace {
   arguments: Record<string, unknown>;
   result_preview: string;
   error: string | null;
+  rewritten_question?: string | null;
 }
 
 export interface AskResponse {

--- a/src/frontend/src/routes/Ask.module.css
+++ b/src/frontend/src/routes/Ask.module.css
@@ -146,3 +146,16 @@
   font-size: 12px;
   white-space: pre-wrap;
 }
+
+.traceRewrite {
+  margin: 0 0 var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background-color: rgba(240, 161, 58, 0.12);
+  color: var(--color-warning);
+  border-radius: var(--radius-md);
+  font-size: 12px;
+}
+
+.traceRewrite code {
+  font-family: var(--font-mono);
+}

--- a/src/frontend/src/routes/Ask.tsx
+++ b/src/frontend/src/routes/Ask.tsx
@@ -104,6 +104,12 @@ export default function Ask() {
                           step {t.iteration}
                         </span>
                       </div>
+                      {t.rewritten_question && (
+                        <div className={styles.traceRewrite}>
+                          クエリを書き換えて再実行しました:{" "}
+                          <code>{t.rewritten_question}</code>
+                        </div>
+                      )}
                       <pre className={styles.traceArgs}>
                         {JSON.stringify(t.arguments, null, 2)}
                       </pre>

--- a/tests/docdb/test_agent.py
+++ b/tests/docdb/test_agent.py
@@ -9,14 +9,34 @@ the three terminating conditions (final answer, max_iters, llm error).
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 
 import pytest
 
 from docdb.agent.loop import SearchAgent
 from docdb.agent.toolbox import Toolbox
-from docdb.llm.fake import FakeLLM, StubChatCompletion
+from docdb.ingestion.store import DocumentStore
+from docdb.llm.fake import FakeLLM, StubChatCompletion, _hash_to_unit_vector
+from docdb.models import Entity, entity_id_for
+from docdb.search.text2sql import GeneratedSQL
 
 from tests.docdb.fixtures import SAMPLE_DOCS
+
+
+@dataclass
+class _KeyedEmbedLLM(FakeLLM):
+    """FakeLLM with text→vector overrides for deterministic KNN tests."""
+
+    embed_overrides: dict[str, list[float]] = field(default_factory=dict)
+
+    def embed(self, texts):
+        self.calls_embed.append(list(texts))
+        return [
+            self.embed_overrides[t]
+            if t in self.embed_overrides
+            else _hash_to_unit_vector(t, self.embed_dim)
+            for t in texts
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +181,64 @@ def test_llm_error_aborts_with_error(populated_db) -> None:
     result = agent.run("?")
     assert not result.succeeded
     assert "ollama unreachable" in result.error
+
+
+def test_agent_trace_carries_rewritten_question_from_text_to_sql(
+    populated_db,
+) -> None:
+    """When ``text_to_sql`` retries via canonicalisation, the rewrite must
+    propagate to the trace entry so the UI can surface it independently
+    of the truncated ``result_preview``."""
+    vec = [0.0] * 1024
+    vec[0] = 1.0
+    alice = Entity(
+        id=entity_id_for("person", "Alice Smith"),
+        type_slug="person",
+        canonical_name="Alice Smith",
+        aliases=["Alice S."],
+    )
+    DocumentStore(populated_db).upsert_entity(alice, embedding=vec)
+
+    question = "Alice S. の件"
+    rewritten = "Alice Smith の件"
+
+    fake = _KeyedEmbedLLM(
+        embed_overrides={question: vec},
+        extract_responses=[
+            # Primary attempt: SQLite errors on bogus column → triggers retry.
+            GeneratedSQL(sql="SELECT bogus FROM entities"),
+            # Retry on the canonicalised question succeeds.
+            GeneratedSQL(sql=f"SELECT id FROM entities WHERE id='{alice.id}'"),
+        ],
+        chat_responses=[
+            StubChatCompletion.tool(
+                [("c1", "text_to_sql", json.dumps({"question": question}))]
+            ),
+            StubChatCompletion.text("Alice Smith に関するレコードを見つけました"),
+        ],
+    )
+    agent = _agent(populated_db, fake)
+
+    result = agent.run(question)
+
+    assert result.succeeded
+    assert [t.tool for t in result.trace] == ["text_to_sql"]
+    assert result.trace[0].rewritten_question == rewritten
+
+
+def test_agent_trace_rewritten_question_is_none_on_happy_path(populated_db) -> None:
+    """Tools that never set ``rewritten_question`` produce ``None`` traces."""
+    fake = FakeLLM(
+        chat_responses=[
+            StubChatCompletion.tool(
+                [("c1", "search_documents", json.dumps({"query": "解約条項"}))]
+            ),
+            StubChatCompletion.text("done"),
+        ]
+    )
+    agent = _agent(populated_db, fake)
+    result = agent.run("?")
+    assert result.trace[0].rewritten_question is None
 
 
 def test_tool_error_is_recorded_but_loop_continues(populated_db) -> None:

--- a/tests/server/test_routes.py
+++ b/tests/server/test_routes.py
@@ -210,6 +210,60 @@ def test_ask_empty_question(client):
     assert res.status_code == 400
 
 
+def test_ask_response_propagates_rewritten_question_in_trace(
+    client, seeded_db, fake_llm
+):
+    """The retry path's canonicalised question must reach the JSON
+    response so the Ask UI can render the rewrite callout independently
+    of the (truncated) ``result_preview``."""
+    from docdb.ingestion import DocumentStore
+    from docdb.models import Entity, entity_id_for
+    from docdb.schema.connection import connection
+    from docdb.search.text2sql import GeneratedSQL
+
+    vec = [0.0] * 1024
+    vec[0] = 1.0
+    alice = Entity(
+        id=entity_id_for("person", "Alice Smith"),
+        type_slug="person",
+        canonical_name="Alice Smith",
+        aliases=["Alice S."],
+    )
+    with connection(seeded_db.db_path) as conn:
+        DocumentStore(conn).upsert_entity(alice, embedding=vec)
+
+    question = "Alice S. の件"
+    rewritten = "Alice Smith の件"
+
+    # Override embed so the question maps to alice's vector; alias
+    # candidate then canonicalises the surface form.
+    fake_llm.embed = lambda texts: [
+        vec if t == question else [0.0] * 1024 for t in texts
+    ]
+    fake_llm.extract_responses.extend(
+        [
+            GeneratedSQL(sql="SELECT bogus FROM entities"),  # primary errors
+            GeneratedSQL(sql=f"SELECT id FROM entities WHERE id='{alice.id}'"),
+        ]
+    )
+    fake_llm.chat_responses.extend(
+        [
+            StubChatCompletion.tool(
+                calls=[("c1", "text_to_sql", json.dumps({"question": question}))]
+            ),
+            StubChatCompletion.text("Alice Smith のレコードを返しました"),
+        ]
+    )
+
+    res = client.post("/api/ask", json={"question": question})
+    assert res.status_code == 200
+    body = res.get_json()
+    assert len(body["trace"]) == 1
+    step = body["trace"][0]
+    assert step["tool"] == "text_to_sql"
+    assert step["rewritten_question"] == rewritten
+
+
 def test_ingest_file(client, tmp_path: Path, fake_llm):
     # Pre-script extraction returns the header only; entity / relation writes
     # are intentionally disabled in Stage 2.


### PR DESCRIPTION
## Summary

When the `text_to_sql` tool retries a question via canonicalization (e.g., resolving an alias to its canonical form), the rewritten question is now captured and propagated through the agent trace so the UI can display it independently of the truncated `result_preview`.

## Changes

- **Backend (`src/docdb/agent/loop.py`)**
  - Added `rewritten_question: str | None` field to `AgentTrace` dataclass
  - Modified `AgentResult.run()` to extract `rewritten_question` from tool invocation results (when present as a dict key)
  - Passes the rewritten question to trace entries for tools that support it

- **Frontend (`src/frontend/src/routes/Ask.tsx`)**
  - Added conditional rendering of rewritten question in trace step display
  - Shows Japanese message "クエリを書き換えて再実行しました:" with the rewritten question in a code block

- **Frontend styling (`src/frontend/src/routes/Ask.module.css`)**
  - Added `.traceRewrite` class with warning-colored background (orange tint) and monospace font for the rewritten query display

- **API types (`src/frontend/src/api/types.ts`)**
  - Added optional `rewritten_question?: string | null` field to `AgentTrace` interface

- **Tests**
  - Added `_KeyedEmbedLLM` test helper class to support deterministic KNN tests with embedding overrides
  - Added `test_agent_trace_carries_rewritten_question_from_text_to_sql()` to verify rewritten questions propagate through agent trace when `text_to_sql` retries via canonicalization
  - Added `test_agent_trace_rewritten_question_is_none_on_happy_path()` to verify tools that don't set rewritten_question produce None traces
  - Added `test_ask_response_propagates_rewritten_question_in_trace()` in server tests to verify the JSON response includes rewritten questions

## Implementation Details

- The `rewritten_question` is extracted from the tool invocation result dictionary, allowing tools like `text_to_sql` to optionally include it when they perform query rewrites
- The field is optional (`None` by default) to maintain backward compatibility with tools that don't support this feature
- The UI displays the rewrite callout only when the field is present and non-null, keeping the trace clean for successful first-attempt queries

https://claude.ai/code/session_01HZZz5ZLULdZnHHLFWwUh5R